### PR TITLE
Use Demystify as browser extension name

### DIFF
--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "browser",
-  "description": "browser extension",
+  "name": "Demystify",
+  "description": "Demystify automatically generates OpenAPI specs from HAR or live network traffic via a proxy",
   "private": true,
   "version": "1.0.0",
   "type": "module",


### PR DESCRIPTION
It appears the extension might still be using a placeholder name?

<img width="434" alt="Screenshot 2025-03-13 at 7 14 31 AM" src="https://github.com/user-attachments/assets/ef8e25a5-a264-4c42-bbdc-15ac9faa2892" />
