### PR TITLE
Make automatic path parameterization safer and configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Example: demystify --input ./example.har
 Options:
   -h, --help                 Show help information
   -i, --input  <string>      A path to a HTTP Archive file (HAR)
+  -p, --parameterisation <string>
+                              Path folding mode: safe-text, id-only, or off
   -s, --stdout <boolean>     Optional: when "true", write a JSON array to stdout instead of writing files
 
 This command writes OpenAPI 3.1 specifications to the current directory

--- a/apps/browser/package.json
+++ b/apps/browser/package.json
@@ -13,7 +13,7 @@
     "zip:firefox": "wxt zip -b firefox",
     "compile": "vue-tsc --noEmit",
     "postinstall": "wxt prepare",
-    "test": "NODE_OPTIONS='--experimental-json-modules' vitest run",
+    "test": "vitest run",
     "test:watch": "vitest watch",
     "test:update": "vitest -u"
   },

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -16,6 +16,8 @@ Example: demystify --input ./example.har
 Options:
   -h, --help                 Show help information
   -i, --input  <string>      A path to a HTTP Archive file (HAR)
+  -p, --parameterisation <string>
+                              Path folding mode: safe-text, id-only, or off
   -s, --stdout <boolean>     Optional: when "true", write a JSON array to stdout instead of writing files
 
 This command writes OpenAPI 3.1 specifications to the current directory

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsup src --no-splitting --external demystify-algorithm && chmod +x ./dist/index.js",
+    "build": "tsup src --no-splitting --external demystify-algorithm && node -e \"if (process.platform !== 'win32') require('node:fs').chmodSync('./dist/index.js', 0o755)\"",
     "prepublish": "npm run build",
     "test": "vitest run",
     "lint": "eslint . --max-warnings 0",

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -2,7 +2,12 @@
 
 import { parseArgs } from "node:util";
 import * as fs from "node:fs";
-import { HarEntry, Representor } from "demystify-lib";
+import {
+  HarEntry,
+  isPathParameterisationMode,
+  pathParameterisationOptionsFromMode,
+  Representor,
+} from "demystify-lib";
 
 const fileExists = async (path: string) => {
   try {
@@ -28,6 +33,10 @@ async function main() {
         type: "boolean",
         short: "s",
       },
+      parameterisation: {
+        type: "string",
+        short: "p",
+      },
     },
   });
 
@@ -41,6 +50,8 @@ Options:
   -h, --help                 Show help information
   -i, --input  <string>      A path to a HTTP Archive file (HAR)
   -s, --stdout <boolean>     Optional: when "true", write a JSON array to stdout instead of writing files
+  -p, --parameterisation <string>
+                              Path folding mode: safe-text, id-only, or off
 
 This command writes OpenAPI 3.1 specifications to the current directory
 Names of these files follow the convention {hostname}.{type}.json
@@ -52,12 +63,21 @@ Example type: openapi
   }
   if (!values.input || !(await fileExists(values.input))) {
     console.error(
-      "The --input [name.har] flag is required and must be a valid HAR file"
+      "The --input [name.har] flag is required and must be a valid HAR file",
+    );
+    process.exit(1);
+  }
+  const parameterisationMode = values.parameterisation || "safe-text";
+  if (!isPathParameterisationMode(parameterisationMode)) {
+    console.error(
+      "The --parameterisation flag must be one of: safe-text, id-only, off",
     );
     process.exit(1);
   }
 
-  const representor = new Representor();
+  const representor = new Representor({
+    parameterisation: pathParameterisationOptionsFromMode(parameterisationMode),
+  });
   try {
     const inputHar = await fs.promises.readFile(values.input, "utf-8");
     const entries = JSON.parse(inputHar).log.entries as HarEntry[];
@@ -65,13 +85,13 @@ Example type: openapi
       for (const entry of entries) {
         representor.upsert(entry);
       }
-    } catch (e) {
+    } catch {
       console.error("Failed to upsert one or more HAR entries");
       process.exit(1);
     }
-  } catch (e) {
+  } catch {
     console.error(
-      'Could not parse the HAR file. It should be JSON, beginning with { "log": ... }'
+      'Could not parse the HAR file. It should be JSON, beginning with { "log": ... }',
     );
     process.exit(1);
   }
@@ -88,7 +108,7 @@ Example type: openapi
     }
   }
   if (output.length) {
-    console.log(`[${output.join(',\n')}]`);
+    console.log(`[${output.join(",\n")}]`);
   }
 }
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -91,7 +91,7 @@ Example type: openapi
     }
   } catch {
     console.error(
-      'Could not parse the HAR file. It should be JSON, beginning with { "log": ... }',
+      'Could not parse the HAR file. It should be JSON, beginning with { "log": ... }'
     );
     process.exit(1);
   }
@@ -108,7 +108,7 @@ Example type: openapi
     }
   }
   if (output.length) {
-    console.log(`[${output.join(",\n")}]`);
+    console.log(`[${output.join(',\n')}]`);
   }
 }
 

--- a/apps/cli/tests/index.test.ts
+++ b/apps/cli/tests/index.test.ts
@@ -1,20 +1,18 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach } from 'vitest';
 import { Validator } from "@seriousme/openapi-schema-validator";
-import { execSync } from "node:child_process";
-import { resolve } from "node:path";
-import { readFileSync, rmSync } from "node:fs";
+import { execSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { readFileSync, rmSync } from 'node:fs';
 
-const inputHar = resolve(__dirname, "./rest_post.json");
-const builtFile = resolve(__dirname, "../dist/index.js");
-const callFile = (stdout?: "-s" | "--stdout") => {
-  const stdOutStr = stdout || "";
-  return execSync(`node ${builtFile} --input ${inputHar} ${stdOutStr}`, {
-    encoding: "utf-8",
-  });
+const inputHar = resolve(__dirname, './rest_post.json');
+const builtFile = resolve(__dirname, '../dist/index.js');
+const callFile = (stdout?: '-s' | '--stdout') => {
+  const stdOutStr = stdout || '';
+  return execSync(`node ${builtFile} --input ${inputHar} ${stdOutStr}`, { encoding: 'utf-8' });
 };
 
-const hostnameOne = "one.com";
-const hostnameTwo = "two.com";
+const hostnameOne = 'one.com';
+const hostnameTwo = 'two.com';
 
 const deleteAllFiles = () => {
   const cwd = process.cwd();
@@ -26,18 +24,18 @@ const readAllFiles = (filenames: string[]): string[] => {
   const cwd = process.cwd();
   const out: string[] = [];
   for (const filename of filenames) {
-    const content = readFileSync(`${cwd}/${filename}.openapi.json`, "utf-8");
+    const content = readFileSync(`${cwd}/${filename}.openapi.json`, 'utf-8');
     out.push(content);
   }
   return out;
-};
+}
 
-describe("CLI", () => {
+describe('CLI', () => {
   afterEach(() => {
     deleteAllFiles();
   });
 
-  it("produces valid openapi files", async () => {
+  it('produces valid openapi files', async () => {
     callFile();
     const jsonArr = readAllFiles([hostnameOne, hostnameTwo]);
     for (const json of jsonArr) {
@@ -46,8 +44,8 @@ describe("CLI", () => {
     }
   });
 
-  it("when -s or --stdout is specified, outputs valid openapi json", async () => {
-    const flags = ["-s", "--stdout"] as const;
+  it('when -s or --stdout is specified, outputs valid openapi json', async () => {
+    const flags = ['-s', '--stdout'] as const;
     for (const flag of flags) {
       const stdout = callFile(flag);
       const stdoutStr = stdout.toString();

--- a/apps/cli/tests/index.test.ts
+++ b/apps/cli/tests/index.test.ts
@@ -1,44 +1,43 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach } from "vitest";
 import { Validator } from "@seriousme/openapi-schema-validator";
-import { execSync } from 'node:child_process';
-import { resolve } from 'node:path';
-import { readFileSync } from 'node:fs';
+import { execSync } from "node:child_process";
+import { resolve } from "node:path";
+import { readFileSync, rmSync } from "node:fs";
 
-const inputHar = resolve(__dirname, './rest_post.json');
-const builtFile = resolve(__dirname, '../dist/index.js');
-const callFile = (stdout?: '-s' | '--stdout') => {
-  const stdOutStr = stdout || '';
-  return execSync(`node ${builtFile} --input ${inputHar} ${stdOutStr}`, { encoding: 'utf-8' });
+const inputHar = resolve(__dirname, "./rest_post.json");
+const builtFile = resolve(__dirname, "../dist/index.js");
+const callFile = (stdout?: "-s" | "--stdout") => {
+  const stdOutStr = stdout || "";
+  return execSync(`node ${builtFile} --input ${inputHar} ${stdOutStr}`, {
+    encoding: "utf-8",
+  });
 };
 
-const hostnameOne = 'one.com';
-const hostnameTwo = 'two.com';
+const hostnameOne = "one.com";
+const hostnameTwo = "two.com";
 
 const deleteAllFiles = () => {
   const cwd = process.cwd();
-  try {
-    execSync(`rm ${cwd}/${hostnameOne}.openapi.json`);
-    execSync(`rm ${cwd}/${hostnameTwo}.openapi.json`);
-  } catch {
-  }
-}
+  rmSync(`${cwd}/${hostnameOne}.openapi.json`, { force: true });
+  rmSync(`${cwd}/${hostnameTwo}.openapi.json`, { force: true });
+};
 
 const readAllFiles = (filenames: string[]): string[] => {
   const cwd = process.cwd();
   const out: string[] = [];
   for (const filename of filenames) {
-    const content = readFileSync(`${cwd}/${filename}.openapi.json`, 'utf-8');
+    const content = readFileSync(`${cwd}/${filename}.openapi.json`, "utf-8");
     out.push(content);
   }
   return out;
-}
+};
 
-describe('CLI', () => {
+describe("CLI", () => {
   afterEach(() => {
     deleteAllFiles();
   });
 
-  it('produces valid openapi files', async () => {
+  it("produces valid openapi files", async () => {
     callFile();
     const jsonArr = readAllFiles([hostnameOne, hostnameTwo]);
     for (const json of jsonArr) {
@@ -47,8 +46,8 @@ describe('CLI', () => {
     }
   });
 
-  it('when -s or --stdout is specified, outputs valid openapi json', async () => {
-    const flags = ['-s', '--stdout'] as const;
+  it("when -s or --stdout is specified, outputs valid openapi json", async () => {
+    const flags = ["-s", "--stdout"] as const;
     for (const flag of flags) {
       const stdout = callFile(flag);
       const stdoutStr = stdout.toString();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,3 @@
+import { config } from "./packages/eslint-config/base.js";
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       }
     },
     "apps/browser": {
-      "name": "Demystify",
+      "name": "demystify-browser",
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {

--- a/packages/algorithm/README.md
+++ b/packages/algorithm/README.md
@@ -5,7 +5,6 @@ Consists of a `Representor` class that accepts HAR entries and triages it. REST-
 See the interface in `Representor.ts` and `Rest.ts` for usage information, along with test files.
 
 Features:
-
 - Real time efficient generation of documents in any format from aggregated data, of which OpenAPI 3.1 is implemented
 - Automatic identification and parameterisation of path parameters
 - Merges new information into existing data
@@ -82,7 +81,7 @@ observation matches an existing dynamic path, it can be merged into that path.
 When Demystify is uncertain, it keeps routes concrete rather than folding them.
 
 ```typescript
-import { Representor } from "demystify-lib";
+import { Representor } from 'demystify-lib';
 // Instantiate the representor
 // Which "represents" an API in a particular way, such as OpenAPI or GraphQL
 const representor = new Representor();

--- a/packages/algorithm/README.md
+++ b/packages/algorithm/README.md
@@ -5,6 +5,7 @@ Consists of a `Representor` class that accepts HAR entries and triages it. REST-
 See the interface in `Representor.ts` and `Rest.ts` for usage information, along with test files.
 
 Features:
+
 - Real time efficient generation of documents in any format from aggregated data, of which OpenAPI 3.1 is implemented
 - Automatic identification and parameterisation of path parameters
 - Merges new information into existing data
@@ -13,8 +14,75 @@ Features:
 - Handles mime types json, x-www-form-urlencoded, and xml
 - Minimal library use
 
+## Automatic path parameterisation
+
+Demystify can fold repeated concrete paths into OpenAPI path parameters when
+the observed requests and responses look like the same endpoint.
+
+The heuristic is conservative:
+
+- Obvious identifier segments such as numeric IDs, UUIDs, long hex values, and
+  long mixed alpha-numeric IDs can be folded after two compatible observations.
+- Text segments are folded only after four compatible observations with the
+  same static path shape.
+- Compatible schema matching allows common variation such as `null` versus a
+  populated object, scalar type changes, and optional nested branches.
+- `null`, empty objects, and empty arrays are treated as unobserved inside that
+  branch. Object, array, and scalar kind conflicts still block folding.
+- Compatible-shape folding still needs positive observed overlap; sparse
+  branches alone are not enough evidence.
+- Generic empty collection wrappers such as
+  `{ count, next, previous, results: [] }` do not trigger text folding by
+  themselves.
+- Incompatible sibling routes stay concrete.
+- Existing dynamic ID paths do not accept later non-ID segments. For example,
+  `/clients/{client}` learned from numeric IDs will not absorb
+  `/clients/search`.
+
+Parameterisation can be configured when constructing a `Representor`:
+
 ```typescript
-import { Representor } from 'demystify-lib';
+import { Representor } from "demystify-lib";
+
+const representor = new Representor({
+  parameterisation: {
+    enabled: true,
+    foldStrongIds: true,
+    foldText: true,
+    compatibleShape: true,
+  },
+});
+```
+
+Options:
+
+- `enabled`: turns automatic path parameterisation on or off.
+- `foldStrongIds`: folds ID-like path values.
+- `foldText`: folds non-ID text path values after enough compatible examples.
+- `compatibleShape`: allows structurally compatible, non-identical schemas.
+  When disabled, exact schema equality is required, while text-route safety
+  checks still apply.
+
+The CLI exposes the common modes:
+
+```shell
+demystify --input ./example.har --parameterisation safe-text
+demystify --input ./example.har --parameterisation id-only
+demystify --input ./example.har --parameterisation off
+```
+
+The shared UI exposes the same options as checkboxes.
+
+Changing parameterisation options in the UI can reprocess HAR data imported
+during the current session. Saved Demystify projects keep their existing
+generated paths when loaded again; changed options apply to future HAR imports.
+
+Demystify does not retroactively split a folded path. If a later compatible
+observation matches an existing dynamic path, it can be merged into that path.
+When Demystify is uncertain, it keeps routes concrete rather than folding them.
+
+```typescript
+import { Representor } from "demystify-lib";
 // Instantiate the representor
 // Which "represents" an API in a particular way, such as OpenAPI or GraphQL
 const representor = new Representor();

--- a/packages/algorithm/package.json
+++ b/packages/algorithm/package.json
@@ -14,7 +14,7 @@
     "build": "vite build",
     "prepack": "npm run build",
     "check-types": "tsc --noEmit",
-    "test": "NODE_OPTIONS='--experimental-json-modules' vitest run",
+    "test": "vitest run",
     "test:watch": "vitest watch",
     "test:update": "vitest -u"
   },

--- a/packages/algorithm/src/generate/generate-oai31.test.ts
+++ b/packages/algorithm/src/generate/generate-oai31.test.ts
@@ -1,19 +1,19 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect } from 'vitest';
 import { Validator } from "@seriousme/openapi-schema-validator";
-import { generateOai31 } from "./generate-oai31.js";
-import { OpenApiBuilder } from "openapi3-ts/oas31";
-import { HostToNode } from "../types/index.js";
-import { Representor } from "../representor.js";
-import { createContent, createHarEntry } from "../__helpers__/index.js";
+import { generateOai31 } from './generate-oai31.js';
+import { OpenApiBuilder } from 'openapi3-ts/oas31';
+import { HostToNode } from '../types/index.js';
+import { Representor } from '../representor.js';
+import { createContent, createHarEntry } from '../__helpers__/index.js';
 
 const validateSpec = (builder: OpenApiBuilder) =>
   new Validator().validate(builder.getSpec());
 
-describe("generateOai31", () => {
+describe('generateOai31', () => {
   const host = "api.example.com";
   const href = `https://${host}`;
 
-  it("should create an OpenAPI builder with correct metadata", async () => {
+  it('should create an OpenAPI builder with correct metadata', async () => {
     const representor = new Representor();
     const response1 = createContent({ test: 1 });
     representor.upsert(
@@ -21,29 +21,29 @@ describe("generateOai31", () => {
         url: `${href}/a/1`,
         response: response1,
         queryString: [{ name: "query", value: "1" }],
-        cookies: [{ name: "token", value: "2" }],
+        cookies: [{ name: "token", value: "2" }]
       }),
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/2`, response: response1 }),
+      createHarEntry({ url: `${href}/a/2`, response: response1 })
     );
     representor.upsert(
       createHarEntry({
         url: `${href}/a/3`,
         response: response1,
         queryString: [{ name: "b", value: "2" }],
-      }),
+      })
     );
     const hostToNode: HostToNode = {
-      [host]: representor.rest.data[host]!,
+      [host]: representor.rest.data[host]!
     };
     const result = generateOai31(hostToNode);
 
     expect(await validateSpec(result)).toEqual({ valid: true });
     expect(result).toBeInstanceOf(OpenApiBuilder);
-    expect(result.rootDoc.openapi).toBe("3.1.0");
-    expect(result.rootDoc.info.title).toBe("OpenAPI Specification");
-    expect(result.rootDoc.info.description).toContain("example.com");
+    expect(result.rootDoc.openapi).toBe('3.1.0');
+    expect(result.rootDoc.info.title).toBe('OpenAPI Specification');
+    expect(result.rootDoc.info.description).toContain('example.com');
     expect(result.rootDoc.servers).toHaveLength(1);
     expect(result.rootDoc.paths!["/a/{a}"]).toEqual({
       post: {
@@ -60,7 +60,9 @@ describe("generateOai31", () => {
                       type: "integer",
                     },
                   },
-                  required: ["test"],
+                  required: [
+                    "test",
+                  ],
                 },
                 example: {
                   test: 1,
@@ -68,7 +70,8 @@ describe("generateOai31", () => {
               },
             },
             description: "",
-            headers: {},
+            headers: {
+            },
           },
         },
         parameters: [
@@ -106,7 +109,7 @@ describe("generateOai31", () => {
             schema: {
               type: "string",
             },
-          },
+          }
         ],
         requestBody: {
           content: {
@@ -118,7 +121,9 @@ describe("generateOai31", () => {
                     type: "string",
                   },
                 },
-                required: ["test"],
+                required: [
+                  "test",
+                ],
               },
               example: {
                 test: "integer",
@@ -127,6 +132,6 @@ describe("generateOai31", () => {
           },
         },
       },
-    });
+    })
   });
 });

--- a/packages/algorithm/src/generate/generate-oai31.test.ts
+++ b/packages/algorithm/src/generate/generate-oai31.test.ts
@@ -1,46 +1,49 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
 import { Validator } from "@seriousme/openapi-schema-validator";
-import { generateOai31 } from './generate-oai31.js';
-import { OpenApiBuilder } from 'openapi3-ts/oas31';
-import { HostToNode } from '../types/index.js';
-import { Representor } from '../representor.js';
-import { createContent, createHarEntry } from '../__helpers__/index.js';
+import { generateOai31 } from "./generate-oai31.js";
+import { OpenApiBuilder } from "openapi3-ts/oas31";
+import { HostToNode } from "../types/index.js";
+import { Representor } from "../representor.js";
+import { createContent, createHarEntry } from "../__helpers__/index.js";
 
 const validateSpec = (builder: OpenApiBuilder) =>
   new Validator().validate(builder.getSpec());
 
-describe('generateOai31', () => {
+describe("generateOai31", () => {
   const host = "api.example.com";
   const href = `https://${host}`;
 
-  it('should create an OpenAPI builder with correct metadata', async () => {
+  it("should create an OpenAPI builder with correct metadata", async () => {
     const representor = new Representor();
     const response1 = createContent({ test: 1 });
-    const response2 = createContent({ test: false });
     representor.upsert(
       createHarEntry({
-        url: `${href}/a/b`,
+        url: `${href}/a/1`,
         response: response1,
         queryString: [{ name: "query", value: "1" }],
-        cookies: [{ name: "token", value: "2" }]
-      })
+        cookies: [{ name: "token", value: "2" }],
+      }),
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/c`, response: response1 })
+      createHarEntry({ url: `${href}/a/2`, response: response1 }),
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/TeSt`, response: response2, queryString: [{ name: "b", value: "2" }] })
+      createHarEntry({
+        url: `${href}/a/3`,
+        response: response1,
+        queryString: [{ name: "b", value: "2" }],
+      }),
     );
     const hostToNode: HostToNode = {
-      [host]: representor.rest.data[host]!
+      [host]: representor.rest.data[host]!,
     };
     const result = generateOai31(hostToNode);
 
     expect(await validateSpec(result)).toEqual({ valid: true });
     expect(result).toBeInstanceOf(OpenApiBuilder);
-    expect(result.rootDoc.openapi).toBe('3.1.0');
-    expect(result.rootDoc.info.title).toBe('OpenAPI Specification');
-    expect(result.rootDoc.info.description).toContain('example.com');
+    expect(result.rootDoc.openapi).toBe("3.1.0");
+    expect(result.rootDoc.info.title).toBe("OpenAPI Specification");
+    expect(result.rootDoc.info.description).toContain("example.com");
     expect(result.rootDoc.servers).toHaveLength(1);
     expect(result.rootDoc.paths!["/a/{a}"]).toEqual({
       post: {
@@ -54,31 +57,25 @@ describe('generateOai31', () => {
                   type: "object",
                   properties: {
                     test: {
-                      type: [
-                        "boolean",
-                        "integer",
-                      ],
+                      type: "integer",
                     },
                   },
-                  required: [
-                    "test",
-                  ],
+                  required: ["test"],
                 },
                 example: {
-                  test: false,
+                  test: 1,
                 },
               },
             },
             description: "",
-            headers: {
-            },
+            headers: {},
           },
         },
         parameters: [
           {
             name: "a",
             in: "path",
-            example: "TeSt",
+            example: "3",
             required: true,
             schema: {
               type: "string",
@@ -109,7 +106,7 @@ describe('generateOai31', () => {
             schema: {
               type: "string",
             },
-          }
+          },
         ],
         requestBody: {
           content: {
@@ -121,9 +118,7 @@ describe('generateOai31', () => {
                     type: "string",
                   },
                 },
-                required: [
-                  "test",
-                ],
+                required: ["test"],
               },
               example: {
                 test: "integer",
@@ -132,6 +127,6 @@ describe('generateOai31', () => {
           },
         },
       },
-    })
+    });
   });
 });

--- a/packages/algorithm/src/har-to-hartype/index.ts
+++ b/packages/algorithm/src/har-to-hartype/index.ts
@@ -15,32 +15,16 @@ import { isValidUrl } from "./is-valid-url.js";
 
 export type Kind = "graphql" | "rest-json" | "rest-xml" | "grpc-web";
 
-interface DiscrimatedUnion {
-  har: HarEntry;
-  kind: Kind;
-}
+type DiscriminatedHar<TKind extends Kind, THar extends HarEntry> = {
+  har: THar;
+  kind: TKind;
+};
 
-interface Gql extends DiscrimatedUnion {
-  har: HarGraphQL;
-  kind: "graphql";
-}
-
-interface RestJson extends DiscrimatedUnion {
-  har: HarRestJson;
-  kind: "rest-json";
-}
-
-interface RestXml extends DiscrimatedUnion {
-  har: HarRestXml;
-  kind: "rest-xml";
-}
-
-interface GrpcWeb extends DiscrimatedUnion {
-  har: HarGrpcWeb;
-  kind: "grpc-web";
-}
-
-export type ValidHar = Gql | RestJson | RestXml | GrpcWeb;
+export type ValidHar =
+  | DiscriminatedHar<"graphql", HarGraphQL>
+  | DiscriminatedHar<"rest-json", HarRestJson>
+  | DiscriminatedHar<"rest-xml", HarRestXml>
+  | DiscriminatedHar<"grpc-web", HarGrpcWeb>;
 
 const discriminateByKind =
   (har: HarEntry) =>

--- a/packages/algorithm/src/index.ts
+++ b/packages/algorithm/src/index.ts
@@ -1,2 +1,3 @@
-export * from './types/index.js';
-export * from './representor.js';
+export * from "./types/index.js";
+export * from "./parameterisation/parameterisation-options.js";
+export * from "./representor.js";

--- a/packages/algorithm/src/index.ts
+++ b/packages/algorithm/src/index.ts
@@ -1,3 +1,3 @@
-export * from "./types/index.js";
-export * from "./parameterisation/parameterisation-options.js";
-export * from "./representor.js";
+export * from './types/index.js';
+export * from './parameterisation/parameterisation-options.js';
+export * from './representor.js';

--- a/packages/algorithm/src/parameterisation/automatic-parameterisation.test.ts
+++ b/packages/algorithm/src/parameterisation/automatic-parameterisation.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { automaticParameterisation } from "./automatic-parameterisation.js";
-import { Representor } from "../representor.js";
-import { createContent, createHarEntry } from "../__helpers__/index.js";
+import { describe, it, expect } from 'vitest';
+import { automaticParameterisation } from './automatic-parameterisation.js';
+import { Representor } from '../representor.js';
+import { createContent, createHarEntry } from '../__helpers__/index.js';
 
 const host = "api.example.com";
 const href = `https://${host}`;
@@ -9,15 +9,15 @@ const mimeType = "application/json";
 const method = "post";
 const statusCode = "200";
 
-describe("automaticParameterisation", () => {
-  it("automatically folds non-strong text paths after four equivalent observations", () => {
+describe('automaticParameterisation', () => {
+  it('automatically folds non-strong text paths after four equivalent observations', () => {
     const representor = new Representor();
-    const response = createContent({ id: 1, title: "Example" });
+    const response = createContent({ id: 1, title: 'Example' });
     for (const slug of [
-      "christopher-taylor",
-      "john-allen",
-      "elisha-rumsey",
-      "mary-smith",
+      'christopher-taylor',
+      'john-allen',
+      'elisha-rumsey',
+      'mary-smith',
     ]) {
       representor.upsert(
         createHarEntry({
@@ -28,16 +28,16 @@ describe("automaticParameterisation", () => {
     }
 
     const data =
-      representor.rest.data["en.wikipedia.org"]!.childrenStatic["api"]!
-        .childrenStatic["rest_v1"]!.childrenStatic["page"]!.childrenStatic[
-        "summary"
+      representor.rest.data['en.wikipedia.org']!.childrenStatic['api']!
+        .childrenStatic['rest_v1']!.childrenStatic['page']!.childrenStatic[
+        'summary'
       ]!;
     expect(Object.keys(data.childrenStatic)).toHaveLength(0);
-    expect(data.childrenDynamic[0]!.key).toBe("{summary}");
+    expect(data.childrenDynamic[0]!.key).toBe('{summary}');
     expect(data.childrenDynamic).toHaveLength(1);
   });
 
-  it("does not automatically fold non-strong text paths before four equivalent observations", () => {
+  it('does not automatically fold non-strong text paths before four equivalent observations', () => {
     const representor = new Representor();
     const response = createContent({ ok: true });
     representor.upsert(
@@ -55,21 +55,21 @@ describe("automaticParameterisation", () => {
 
     const paths = representor.rest.generate().getSpec().paths || {};
     expect(Object.keys(paths).sort()).toEqual([
-      "/command/core/get-preference",
-      "/command/core/list-preferences",
-      "/command/core/set-preference",
+      '/command/core/get-preference',
+      '/command/core/list-preferences',
+      '/command/core/set-preference',
     ]);
   });
 
-  it("automatically folds non-strong text paths after four compatible shape observations", () => {
+  it('automatically folds non-strong text paths after four compatible shape observations', () => {
     const representor = new Representor();
     const responses = [
-      createContent({ id: 1, status: "ready", meta: null }),
+      createContent({ id: 1, status: 'ready', meta: null }),
       createContent({ id: 2, status: false, meta: null }),
-      createContent({ id: 3, status: "ready", meta: { id: 1, title: "A" } }),
-      createContent({ id: 4, status: true, meta: { id: 2, title: "B" } }),
+      createContent({ id: 3, status: 'ready', meta: { id: 1, title: 'A' } }),
+      createContent({ id: 4, status: true, meta: { id: 2, title: 'B' } }),
     ];
-    for (const [idx, slug] of ["alpha", "beta", "gamma", "delta"].entries()) {
+    for (const [idx, slug] of ['alpha', 'beta', 'gamma', 'delta'].entries()) {
       representor.upsert(
         createHarEntry({
           url: `${href}/api/page/${slug}`,
@@ -79,10 +79,10 @@ describe("automaticParameterisation", () => {
     }
 
     const paths = representor.rest.generate().getSpec().paths || {};
-    expect(Object.keys(paths).sort()).toEqual(["/api/page/{page}"]);
+    expect(Object.keys(paths).sort()).toEqual(['/api/page/{page}']);
   });
 
-  it("does not fold generic empty collection wrappers as text paths", () => {
+  it('does not fold generic empty collection wrappers as text paths', () => {
     const representor = new Representor();
     const response = createContent({
       count: 0,
@@ -90,7 +90,7 @@ describe("automaticParameterisation", () => {
       previous: null,
       results: [],
     });
-    for (const resource of ["clients", "orders", "leads", "tasks"]) {
+    for (const resource of ['clients', 'orders', 'leads', 'tasks']) {
       representor.upsert(
         createHarEntry({ url: `${href}/api/v2/${resource}`, response }),
       );
@@ -98,14 +98,14 @@ describe("automaticParameterisation", () => {
 
     const paths = representor.rest.generate().getSpec().paths || {};
     expect(Object.keys(paths).sort()).toEqual([
-      "/api/v2/clients",
-      "/api/v2/leads",
-      "/api/v2/orders",
-      "/api/v2/tasks",
+      '/api/v2/clients',
+      '/api/v2/leads',
+      '/api/v2/orders',
+      '/api/v2/tasks',
     ]);
   });
 
-  it("keeps text safety checks when compatible shape matching is disabled", () => {
+  it('keeps text safety checks when compatible shape matching is disabled', () => {
     const representor = new Representor({
       parameterisation: { compatibleShape: false },
     });
@@ -115,7 +115,7 @@ describe("automaticParameterisation", () => {
       previous: null,
       results: [],
     });
-    for (const resource of ["clients", "orders", "leads", "tasks"]) {
+    for (const resource of ['clients', 'orders', 'leads', 'tasks']) {
       representor.upsert(
         createHarEntry({ url: `${href}/api/v2/${resource}`, response }),
       );
@@ -123,14 +123,14 @@ describe("automaticParameterisation", () => {
 
     const paths = representor.rest.generate().getSpec().paths || {};
     expect(Object.keys(paths).sort()).toEqual([
-      "/api/v2/clients",
-      "/api/v2/leads",
-      "/api/v2/orders",
-      "/api/v2/tasks",
+      '/api/v2/clients',
+      '/api/v2/leads',
+      '/api/v2/orders',
+      '/api/v2/tasks',
     ]);
   });
 
-  it("should automatically update to /a/{} given /a and /a/3/c", () => {
+  it('should automatically update to /a/{} given /a and /a/3/c', () => {
     // Test after upserting observations
     // /a/1 -> request1 (match)
     // /a/2 -> request1 (match)
@@ -174,10 +174,12 @@ describe("automaticParameterisation", () => {
     ).toEqual({
       properties: {
         test: {
-          type: ["boolean", "integer"],
+          type: ["boolean", "integer"]
         },
       },
-      required: ["test"],
+      required: [
+        "test",
+      ],
       type: "object",
     });
     const lvl2dynamic = lvl1.childrenDynamic[0]!;
@@ -191,7 +193,7 @@ describe("automaticParameterisation", () => {
     expect(lvl2static.key).toBe("3");
   });
 
-  it("does not collapse collection resource names into a path parameter", () => {
+  it('does not collapse collection resource names into a path parameter', () => {
     const representor = new Representor();
     const response = createContent({ data: [] });
     representor.upsert(
@@ -203,14 +205,14 @@ describe("automaticParameterisation", () => {
 
     const paths = representor.rest.generate().getSpec().paths || {};
     expect(Object.keys(paths).sort()).toEqual([
-      "/api/v2/clients",
-      "/api/v2/orders",
+      '/api/v2/clients',
+      '/api/v2/orders',
     ]);
   });
 
-  it("does not merge same-depth routes outside the proposed parameterised path", () => {
+  it('does not merge same-depth routes outside the proposed parameterised path', () => {
     const representor = new Representor();
-    const response = createContent({ id: 1, name: "example" });
+    const response = createContent({ id: 1, name: 'example' });
     representor.upsert(
       createHarEntry({ url: `${href}/api/v2/clients/109401`, response }),
     );
@@ -223,14 +225,14 @@ describe("automaticParameterisation", () => {
 
     const paths = representor.rest.generate().getSpec().paths || {};
     expect(Object.keys(paths).sort()).toEqual([
-      "/api/v2/clients/{client}",
-      "/api/v2/orders/43685",
+      '/api/v2/clients/{client}',
+      '/api/v2/orders/43685',
     ]);
   });
 
-  it("does not merge non-equivalent same-parent routes into a folded ID path", () => {
+  it('does not merge non-equivalent same-parent routes into a folded ID path', () => {
     const representor = new Representor();
-    const clientResponse = createContent({ id: 1, name: "Example" });
+    const clientResponse = createContent({ id: 1, name: 'Example' });
     const searchResponse = createContent({ results: [] });
     representor.upsert(
       createHarEntry({
@@ -253,20 +255,20 @@ describe("automaticParameterisation", () => {
 
     const paths = representor.rest.generate().getSpec().paths || {};
     expect(Object.keys(paths).sort()).toEqual([
-      "/api/v2/clients/search",
-      "/api/v2/clients/{client}",
+      '/api/v2/clients/search',
+      '/api/v2/clients/{client}',
     ]);
   });
 
-  it("folds strong ID paths with compatible response shapes", () => {
+  it('folds strong ID paths with compatible response shapes', () => {
     const representor = new Representor();
     representor.upsert(
       createHarEntry({
         url: `${href}/api/v2/orders/46068`,
         response: createContent({
           id: 46068,
-          status: "ready",
-          provider: { id: 1, name: "Provider" },
+          status: 'ready',
+          provider: { id: 1, name: 'Provider' },
           extra: null,
         }),
       }),
@@ -277,19 +279,19 @@ describe("automaticParameterisation", () => {
         response: createContent({
           id: 49212,
           status: false,
-          provider: { id: 1, name: "Provider", logo: "logo.png" },
-          extra: { id: 7, title: "Additional" },
+          provider: { id: 1, name: 'Provider', logo: 'logo.png' },
+          extra: { id: 7, title: 'Additional' },
         }),
       }),
     );
 
     const paths = representor.rest.generate().getSpec().paths || {};
-    expect(Object.keys(paths).sort()).toEqual(["/api/v2/orders/{order}"]);
+    expect(Object.keys(paths).sort()).toEqual(['/api/v2/orders/{order}']);
   });
 
-  it("folds strong ID paths when observed URLs include query strings", () => {
+  it('folds strong ID paths when observed URLs include query strings', () => {
     const representor = new Representor();
-    const response = createContent({ id: 1, name: "Example" });
+    const response = createContent({ id: 1, name: 'Example' });
     representor.upsert(
       createHarEntry({
         url: `${href}/api/v2/orders/46068?include=details`,
@@ -304,15 +306,15 @@ describe("automaticParameterisation", () => {
     );
 
     const paths = representor.rest.generate().getSpec().paths || {};
-    expect(Object.keys(paths).sort()).toEqual(["/api/v2/orders/{order}"]);
+    expect(Object.keys(paths).sort()).toEqual(['/api/v2/orders/{order}']);
   });
 
-  it("keeps static action suffixes when folding IDs below an existing dynamic path", () => {
+  it('keeps static action suffixes when folding IDs below an existing dynamic path', () => {
     const representor = new Representor({
       parameterisation: { foldText: false },
     });
-    const orderResponse = createContent({ id: 1, status: "ready" });
-    const actionResponse = createContent({ id: 1, action: "repeat-sell" });
+    const orderResponse = createContent({ id: 1, status: 'ready' });
+    const actionResponse = createContent({ id: 1, action: 'repeat-sell' });
 
     representor.upsert(
       createHarEntry({
@@ -341,14 +343,14 @@ describe("automaticParameterisation", () => {
 
     const paths = representor.rest.generate().getSpec().paths || {};
     expect(Object.keys(paths).sort()).toEqual([
-      "/api/v2/orders/{order}",
-      "/api/v2/orders/{order}/repeat-sell",
+      '/api/v2/orders/{order}',
+      '/api/v2/orders/{order}/repeat-sell',
     ]);
   });
 
-  it("folds varying action suffixes below an ID when text folding is enabled", () => {
+  it('folds varying action suffixes below an ID when text folding is enabled', () => {
     const representor = new Representor();
-    const response = createContent({ id: 1, status: "ready" });
+    const response = createContent({ id: 1, status: 'ready' });
     const actionResponse = createContent({ id: 1, ok: true });
 
     representor.upsert(
@@ -358,10 +360,10 @@ describe("automaticParameterisation", () => {
       createHarEntry({ url: `${href}/api/v2/orders/3456`, response }),
     );
     for (const [orderId, action] of [
-      ["1234", "repeat-sell"],
-      ["2345", "cancel"],
-      ["3456", "restore"],
-      ["4567", "archive"],
+      ['1234', 'repeat-sell'],
+      ['2345', 'cancel'],
+      ['3456', 'restore'],
+      ['4567', 'archive'],
     ]) {
       representor.upsert(
         createHarEntry({
@@ -373,16 +375,16 @@ describe("automaticParameterisation", () => {
 
     const paths = representor.rest.generate().getSpec().paths || {};
     expect(Object.keys(paths).sort()).toEqual([
-      "/api/v2/orders/{order}",
-      "/api/v2/orders/{order}/{param5}",
+      '/api/v2/orders/{order}',
+      '/api/v2/orders/{order}/{param5}',
     ]);
   });
 
-  it("does not fold varying action suffixes when text folding is disabled", () => {
+  it('does not fold varying action suffixes when text folding is disabled', () => {
     const representor = new Representor({
       parameterisation: { foldText: false },
     });
-    const response = createContent({ id: 1, status: "ready" });
+    const response = createContent({ id: 1, status: 'ready' });
     const actionResponse = createContent({ id: 1, ok: true });
 
     representor.upsert(
@@ -392,10 +394,10 @@ describe("automaticParameterisation", () => {
       createHarEntry({ url: `${href}/api/v2/orders/3456`, response }),
     );
     for (const [orderId, action] of [
-      ["1234", "repeat-sell"],
-      ["2345", "cancel"],
-      ["3456", "restore"],
-      ["4567", "archive"],
+      ['1234', 'repeat-sell'],
+      ['2345', 'cancel'],
+      ['3456', 'restore'],
+      ['4567', 'archive'],
     ]) {
       representor.upsert(
         createHarEntry({
@@ -407,15 +409,15 @@ describe("automaticParameterisation", () => {
 
     const paths = representor.rest.generate().getSpec().paths || {};
     expect(Object.keys(paths).sort()).toEqual([
-      "/api/v2/orders/1234/repeat-sell",
-      "/api/v2/orders/2345/cancel",
-      "/api/v2/orders/3456/restore",
-      "/api/v2/orders/4567/archive",
-      "/api/v2/orders/{order}",
+      '/api/v2/orders/1234/repeat-sell',
+      '/api/v2/orders/2345/cancel',
+      '/api/v2/orders/3456/restore',
+      '/api/v2/orders/4567/archive',
+      '/api/v2/orders/{order}',
     ]);
   });
 
-  it("routes later ID examples with sparse optional branches into an existing dynamic path", () => {
+  it('routes later ID examples with sparse optional branches into an existing dynamic path', () => {
     const representor = new Representor();
     const actionMaster = Object.fromEntries(
       Array.from({ length: 15 }, (_, index) => [
@@ -430,10 +432,10 @@ describe("automaticParameterisation", () => {
       ]),
     );
     const tariffResponse = {
-      title: "Tariff",
+      title: 'Tariff',
       price: 100,
       is_active: true,
-      provider: { id: 1, title: "Provider", website: "https://example.com" },
+      provider: { id: 1, title: 'Provider', website: 'https://example.com' },
     };
 
     representor.upsert(
@@ -446,7 +448,7 @@ describe("automaticParameterisation", () => {
           tariff_options: [
             {
               id: 1,
-              value: "enabled",
+              value: 'enabled',
               tariff_option_type: tariffOptionType,
             },
           ],
@@ -463,7 +465,7 @@ describe("automaticParameterisation", () => {
           tariff_options: [
             {
               id: 2,
-              value: "disabled",
+              value: 'disabled',
               tariff_option_type: tariffOptionType,
             },
           ],
@@ -484,11 +486,11 @@ describe("automaticParameterisation", () => {
 
     const paths = representor.rest.generate().getSpec().paths || {};
     expect(Object.keys(paths).sort()).toEqual([
-      "/api/v2/tariffs-proxy/{tariffs-proxy}",
+      '/api/v2/tariffs-proxy/{tariffs-proxy}',
     ]);
   });
 
-  it("does not treat a tiny sparse strong ID shape as compatible with a richer shape", () => {
+  it('does not treat a tiny sparse strong ID shape as compatible with a richer shape', () => {
     const representor = new Representor();
     representor.upsert(
       createHarEntry({
@@ -501,27 +503,27 @@ describe("automaticParameterisation", () => {
         url: `${href}/api/v2/orders/49212`,
         response: createContent({
           id: 49212,
-          status: "ready",
-          provider: { id: 1, name: "Provider" },
+          status: 'ready',
+          provider: { id: 1, name: 'Provider' },
         }),
       }),
     );
 
     const paths = representor.rest.generate().getSpec().paths || {};
     expect(Object.keys(paths).sort()).toEqual([
-      "/api/v2/orders/46068",
-      "/api/v2/orders/49212",
+      '/api/v2/orders/46068',
+      '/api/v2/orders/49212',
     ]);
   });
 
-  it("can disable compatible shape matching", () => {
+  it('can disable compatible shape matching', () => {
     const representor = new Representor({
       parameterisation: { compatibleShape: false },
     });
     representor.upsert(
       createHarEntry({
         url: `${href}/api/v2/orders/46068`,
-        response: createContent({ id: 46068, status: "ready" }),
+        response: createContent({ id: 46068, status: 'ready' }),
       }),
     );
     representor.upsert(
@@ -533,16 +535,16 @@ describe("automaticParameterisation", () => {
 
     const paths = representor.rest.generate().getSpec().paths || {};
     expect(Object.keys(paths).sort()).toEqual([
-      "/api/v2/orders/46068",
-      "/api/v2/orders/49212",
+      '/api/v2/orders/46068',
+      '/api/v2/orders/49212',
     ]);
   });
 
-  it("can disable strong ID folding", () => {
+  it('can disable strong ID folding', () => {
     const representor = new Representor({
       parameterisation: { foldStrongIds: false },
     });
-    const response = createContent({ id: 1, status: "ready" });
+    const response = createContent({ id: 1, status: 'ready' });
     representor.upsert(
       createHarEntry({ url: `${href}/api/v2/orders/46068`, response }),
     );
@@ -552,17 +554,17 @@ describe("automaticParameterisation", () => {
 
     const paths = representor.rest.generate().getSpec().paths || {};
     expect(Object.keys(paths).sort()).toEqual([
-      "/api/v2/orders/46068",
-      "/api/v2/orders/49212",
+      '/api/v2/orders/46068',
+      '/api/v2/orders/49212',
     ]);
   });
 
-  it("can disable text folding", () => {
+  it('can disable text folding', () => {
     const representor = new Representor({
       parameterisation: { foldText: false },
     });
-    const response = createContent({ id: 1, title: "Example" });
-    for (const slug of ["alpha", "beta", "gamma", "delta"]) {
+    const response = createContent({ id: 1, title: 'Example' });
+    for (const slug of ['alpha', 'beta', 'gamma', 'delta']) {
       representor.upsert(
         createHarEntry({ url: `${href}/api/page/${slug}`, response }),
       );
@@ -570,18 +572,18 @@ describe("automaticParameterisation", () => {
 
     const paths = representor.rest.generate().getSpec().paths || {};
     expect(Object.keys(paths).sort()).toEqual([
-      "/api/page/alpha",
-      "/api/page/beta",
-      "/api/page/delta",
-      "/api/page/gamma",
+      '/api/page/alpha',
+      '/api/page/beta',
+      '/api/page/delta',
+      '/api/page/gamma',
     ]);
   });
 
-  it("can disable automatic folding", () => {
+  it('can disable automatic folding', () => {
     const representor = new Representor({
       parameterisation: { enabled: false },
     });
-    const response = createContent({ id: 1, status: "ready" });
+    const response = createContent({ id: 1, status: 'ready' });
     representor.upsert(
       createHarEntry({ url: `${href}/api/v2/orders/46068`, response }),
     );
@@ -591,15 +593,15 @@ describe("automaticParameterisation", () => {
 
     const paths = representor.rest.generate().getSpec().paths || {};
     expect(Object.keys(paths).sort()).toEqual([
-      "/api/v2/orders/46068",
-      "/api/v2/orders/49212",
+      '/api/v2/orders/46068',
+      '/api/v2/orders/49212',
     ]);
   });
 
-  it("preserves parent endpoint data when child leaves are folded", () => {
+  it('preserves parent endpoint data when child leaves are folded', () => {
     const representor = new Representor();
     const parentResponse = createContent({ total: 2 });
-    const childResponse = createContent({ id: 1, name: "Example" });
+    const childResponse = createContent({ id: 1, name: 'Example' });
     representor.upsert(
       createHarEntry({ url: `${href}/a`, response: parentResponse }),
     );
@@ -611,17 +613,17 @@ describe("automaticParameterisation", () => {
     );
 
     const paths = representor.rest.generate().getSpec().paths || {};
-    expect(Object.keys(paths).sort()).toEqual(["/a", "/a/{a}"]);
-    expect(paths["/a"]?.post?.responses?.["200"]?.content?.[mimeType]).toEqual(
+    expect(Object.keys(paths).sort()).toEqual(['/a', '/a/{a}']);
+    expect(paths['/a']?.post?.responses?.['200']?.content?.[mimeType]).toEqual(
       expect.objectContaining({
         example: { total: 2 },
       }),
     );
   });
 
-  it("does not overwrite an existing folded ID path with an incompatible ID cluster", () => {
+  it('does not overwrite an existing folded ID path with an incompatible ID cluster', () => {
     const representor = new Representor();
-    const clientResponse = createContent({ id: 1, name: "Example" });
+    const clientResponse = createContent({ id: 1, name: 'Example' });
     const billingResponse = createContent({ id: 1, total: 100 });
     representor.upsert(
       createHarEntry({
@@ -649,22 +651,22 @@ describe("automaticParameterisation", () => {
     );
 
     const clientsNode =
-      representor.rest.data[host]!.childrenStatic["api"]!.childrenStatic["v2"]!
-        .childrenStatic["clients"]!;
+      representor.rest.data[host]!.childrenStatic['api']!.childrenStatic['v2']!
+        .childrenStatic['clients']!;
     expect(clientsNode.childrenDynamic).toHaveLength(1);
     expect(Object.keys(clientsNode.childrenStatic).sort()).toEqual([
-      "126364",
-      "126365",
+      '126364',
+      '126365',
     ]);
     const dynamicResponseBody =
       clientsNode.childrenDynamic[0]!.data?.methods[method]?.response?.[
-        "200"
+        '200'
       ]?.[mimeType]?.body;
-    expect(dynamicResponseBody?.properties?.["name"]?.type).toBe("string");
-    expect(dynamicResponseBody?.properties?.["total"]).toBeUndefined();
+    expect(dynamicResponseBody?.properties?.['name']?.type).toBe('string');
+    expect(dynamicResponseBody?.properties?.['total']).toBeUndefined();
   });
 
-  it("does not collapse command names into a path parameter", () => {
+  it('does not collapse command names into a path parameter', () => {
     const representor = new Representor();
     const response = createContent({ ok: true });
     representor.upsert(
@@ -676,8 +678,8 @@ describe("automaticParameterisation", () => {
 
     const paths = representor.rest.generate().getSpec().paths || {};
     expect(Object.keys(paths).sort()).toEqual([
-      "/command/core/get-preference",
-      "/command/core/set-preference",
+      '/command/core/get-preference',
+      '/command/core/set-preference',
     ]);
   });
 });

--- a/packages/algorithm/src/parameterisation/automatic-parameterisation.test.ts
+++ b/packages/algorithm/src/parameterisation/automatic-parameterisation.test.ts
@@ -307,6 +307,114 @@ describe("automaticParameterisation", () => {
     expect(Object.keys(paths).sort()).toEqual(["/api/v2/orders/{order}"]);
   });
 
+  it("keeps static action suffixes when folding IDs below an existing dynamic path", () => {
+    const representor = new Representor({
+      parameterisation: { foldText: false },
+    });
+    const orderResponse = createContent({ id: 1, status: "ready" });
+    const actionResponse = createContent({ id: 1, action: "repeat-sell" });
+
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/orders/1234`,
+        response: orderResponse,
+      }),
+    );
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/orders/3456`,
+        response: orderResponse,
+      }),
+    );
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/orders/1234/repeat-sell`,
+        response: actionResponse,
+      }),
+    );
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/orders/3456/repeat-sell`,
+        response: actionResponse,
+      }),
+    );
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual([
+      "/api/v2/orders/{order}",
+      "/api/v2/orders/{order}/repeat-sell",
+    ]);
+  });
+
+  it("folds varying action suffixes below an ID when text folding is enabled", () => {
+    const representor = new Representor();
+    const response = createContent({ id: 1, status: "ready" });
+    const actionResponse = createContent({ id: 1, ok: true });
+
+    representor.upsert(
+      createHarEntry({ url: `${href}/api/v2/orders/1234`, response }),
+    );
+    representor.upsert(
+      createHarEntry({ url: `${href}/api/v2/orders/3456`, response }),
+    );
+    for (const [orderId, action] of [
+      ["1234", "repeat-sell"],
+      ["2345", "cancel"],
+      ["3456", "restore"],
+      ["4567", "archive"],
+    ]) {
+      representor.upsert(
+        createHarEntry({
+          url: `${href}/api/v2/orders/${orderId}/${action}`,
+          response: actionResponse,
+        }),
+      );
+    }
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual([
+      "/api/v2/orders/{order}",
+      "/api/v2/orders/{order}/{param5}",
+    ]);
+  });
+
+  it("does not fold varying action suffixes when text folding is disabled", () => {
+    const representor = new Representor({
+      parameterisation: { foldText: false },
+    });
+    const response = createContent({ id: 1, status: "ready" });
+    const actionResponse = createContent({ id: 1, ok: true });
+
+    representor.upsert(
+      createHarEntry({ url: `${href}/api/v2/orders/1234`, response }),
+    );
+    representor.upsert(
+      createHarEntry({ url: `${href}/api/v2/orders/3456`, response }),
+    );
+    for (const [orderId, action] of [
+      ["1234", "repeat-sell"],
+      ["2345", "cancel"],
+      ["3456", "restore"],
+      ["4567", "archive"],
+    ]) {
+      representor.upsert(
+        createHarEntry({
+          url: `${href}/api/v2/orders/${orderId}/${action}`,
+          response: actionResponse,
+        }),
+      );
+    }
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual([
+      "/api/v2/orders/1234/repeat-sell",
+      "/api/v2/orders/2345/cancel",
+      "/api/v2/orders/3456/restore",
+      "/api/v2/orders/4567/archive",
+      "/api/v2/orders/{order}",
+    ]);
+  });
+
   it("routes later ID examples with sparse optional branches into an existing dynamic path", () => {
     const representor = new Representor();
     const actionMaster = Object.fromEntries(

--- a/packages/algorithm/src/parameterisation/automatic-parameterisation.test.ts
+++ b/packages/algorithm/src/parameterisation/automatic-parameterisation.test.ts
@@ -1,95 +1,183 @@
-import { describe, it, expect } from 'vitest';
-import { automaticParameterisation } from './automatic-parameterisation.js';
-import { Representor } from '../representor.js';
-import { createContent, createHarEntry } from '../__helpers__/index.js';
-import parameterisedCallsHar1 from "../__fixtures__/parameterisedcalls1.json" with { type: "json"};
-import { Entry } from 'har-format';
+import { describe, it, expect } from "vitest";
+import { automaticParameterisation } from "./automatic-parameterisation.js";
+import { Representor } from "../representor.js";
+import { createContent, createHarEntry } from "../__helpers__/index.js";
 
 const host = "api.example.com";
 const href = `https://${host}`;
 const mimeType = "application/json";
 const method = "post";
+const statusCode = "200";
 
-describe('automaticParameterisation', () => {
-  it('should automatically update to /a/b/c/d/{dynamic}', () => {
-    const pathname = ["api", "rest_v1", "page", "summary", "elisha_rumsey"];
+describe("automaticParameterisation", () => {
+  it("automatically folds non-strong text paths after four equivalent observations", () => {
     const representor = new Representor();
-    for (const entry of parameterisedCallsHar1.log.entries) {
-      representor.upsert(entry as Entry);
+    const response = createContent({ id: 1, title: "Example" });
+    for (const slug of [
+      "christopher-taylor",
+      "john-allen",
+      "elisha-rumsey",
+      "mary-smith",
+    ]) {
+      representor.upsert(
+        createHarEntry({
+          url: `https://en.wikipedia.org/api/rest_v1/page/summary/${slug}`,
+          response,
+        }),
+      );
     }
-    const insertedNode = representor.rest.data["en.wikipedia.org"]!
-      .childrenStatic["api"]!
-      .childrenStatic["rest_v1"]!
-      .childrenStatic["page"]!
-      .childrenStatic["summary"]!
-      .childrenDynamic[0]!;
-    automaticParameterisation({
-      pathname,
-      insertedNode,
-      rootNode: representor.rest.data["en.wikipedia.org"]!,
-      method,
-      mimeType,
-    });
-    const data = representor.rest.data["en.wikipedia.org"]!
-      .childrenStatic["api"]!
-      .childrenStatic["rest_v1"]!
-      .childrenStatic["page"]!
-      .childrenStatic["summary"]!
+
+    const data =
+      representor.rest.data["en.wikipedia.org"]!.childrenStatic["api"]!
+        .childrenStatic["rest_v1"]!.childrenStatic["page"]!.childrenStatic[
+        "summary"
+      ]!;
     expect(Object.keys(data.childrenStatic)).toHaveLength(0);
     expect(data.childrenDynamic[0]!.key).toBe("{summary}");
     expect(data.childrenDynamic).toHaveLength(1);
   });
 
-  it('should automatically update to /a/{} given /a and /a/b/c', () => {
+  it("does not automatically fold non-strong text paths before four equivalent observations", () => {
+    const representor = new Representor();
+    const response = createContent({ ok: true });
+    representor.upsert(
+      createHarEntry({ url: `${href}/command/core/get-preference`, response }),
+    );
+    representor.upsert(
+      createHarEntry({ url: `${href}/command/core/set-preference`, response }),
+    );
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/command/core/list-preferences`,
+        response,
+      }),
+    );
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual([
+      "/command/core/get-preference",
+      "/command/core/list-preferences",
+      "/command/core/set-preference",
+    ]);
+  });
+
+  it("automatically folds non-strong text paths after four compatible shape observations", () => {
+    const representor = new Representor();
+    const responses = [
+      createContent({ id: 1, status: "ready", meta: null }),
+      createContent({ id: 2, status: false, meta: null }),
+      createContent({ id: 3, status: "ready", meta: { id: 1, title: "A" } }),
+      createContent({ id: 4, status: true, meta: { id: 2, title: "B" } }),
+    ];
+    for (const [idx, slug] of ["alpha", "beta", "gamma", "delta"].entries()) {
+      representor.upsert(
+        createHarEntry({
+          url: `${href}/api/page/${slug}`,
+          response: responses[idx],
+        }),
+      );
+    }
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual(["/api/page/{page}"]);
+  });
+
+  it("does not fold generic empty collection wrappers as text paths", () => {
+    const representor = new Representor();
+    const response = createContent({
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    });
+    for (const resource of ["clients", "orders", "leads", "tasks"]) {
+      representor.upsert(
+        createHarEntry({ url: `${href}/api/v2/${resource}`, response }),
+      );
+    }
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual([
+      "/api/v2/clients",
+      "/api/v2/leads",
+      "/api/v2/orders",
+      "/api/v2/tasks",
+    ]);
+  });
+
+  it("keeps text safety checks when compatible shape matching is disabled", () => {
+    const representor = new Representor({
+      parameterisation: { compatibleShape: false },
+    });
+    const response = createContent({
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    });
+    for (const resource of ["clients", "orders", "leads", "tasks"]) {
+      representor.upsert(
+        createHarEntry({ url: `${href}/api/v2/${resource}`, response }),
+      );
+    }
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual([
+      "/api/v2/clients",
+      "/api/v2/leads",
+      "/api/v2/orders",
+      "/api/v2/tasks",
+    ]);
+  });
+
+  it("should automatically update to /a/{} given /a and /a/3/c", () => {
     // Test after upserting observations
-    // /a/b -> request1 (match)
-    // /a/c -> request1 (match)
+    // /a/1 -> request1 (match)
+    // /a/2 -> request1 (match)
     // /a -> request2
     // /a -> request1
-    // /a/b/c -> request1
-    // Then parameterise path ["a", "b"]
+    // /a/3/c -> request1
+    // Then parameterise path ["a", "1"]
     // This gives
     // /a -> request1 & request2
     // /a/{} -> request1
-    // /a/b/c -> request1
-    const pathname = ["a", "b"];
+    // /a/3/c -> request1
+    const pathname = ["a", "1"];
     const representor = new Representor();
     const request1 = createContent({ test: 1 });
     const request2 = createContent({ test: false });
     representor.upsert(
-      createHarEntry({ url: `${href}/a/b`, request: request1 })
+      createHarEntry({ url: `${href}/a/1`, request: request1 }),
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/c`, request: request1 })
+      createHarEntry({ url: `${href}/a/2`, request: request1 }),
     );
+    representor.upsert(createHarEntry({ url: `${href}/a`, request: request2 }));
+    representor.upsert(createHarEntry({ url: `${href}/a`, request: request1 }));
     representor.upsert(
-      createHarEntry({ url: `${href}/a`, request: request2 })
+      createHarEntry({ url: `${href}/a/3/c`, request: request1 }),
     );
-    representor.upsert(
-      createHarEntry({ url: `${href}/a`, request: request1 })
-    );
-    representor.upsert(
-      createHarEntry({ url: `${href}/a/b/c`, request: request1 })
-    );
-    const insertedNode = representor.rest.data[host]!.childrenStatic["a"]!.childrenDynamic[0]!;
+    const insertedNode =
+      representor.rest.data[host]!.childrenStatic["a"]!.childrenDynamic[0]!;
     automaticParameterisation({
       pathname,
       insertedNode,
       rootNode: representor.rest.data[host]!,
       method,
       mimeType,
+      statusCode,
     });
-    let node = representor.rest.data[host]!;
-    const lvl1 = node.childrenStatic["a"]!
-    expect(lvl1.data?.methods["post"]!.request!["application/json"]?.body).toEqual({
+    const node = representor.rest.data[host]!;
+    const lvl1 = node.childrenStatic["a"]!;
+    expect(
+      lvl1.data?.methods["post"]!.request!["application/json"]?.body,
+    ).toEqual({
       properties: {
         test: {
-          type: ["boolean", "integer"]
-        }
+          type: ["boolean", "integer"],
+        },
       },
-      required: [
-        "test",
-      ],
+      required: ["test"],
       type: "object",
     });
     const lvl2dynamic = lvl1.childrenDynamic[0]!;
@@ -98,8 +186,390 @@ describe('automaticParameterisation', () => {
     expect(lvl2dynamic.parent).not.toBeNull();
     expect(lvl2dynamic.key).toBe("{a}");
     expect(lvl2dynamic.data).not.toBeNull();
-    const lvl2static = lvl1.childrenStatic["b"]!;
+    const lvl2static = lvl1.childrenStatic["3"]!;
     expect(lvl2static.data).toBeNull();
-    expect(lvl2static.key).toBe("b");
+    expect(lvl2static.key).toBe("3");
+  });
+
+  it("does not collapse collection resource names into a path parameter", () => {
+    const representor = new Representor();
+    const response = createContent({ data: [] });
+    representor.upsert(
+      createHarEntry({ url: `${href}/api/v2/clients`, response }),
+    );
+    representor.upsert(
+      createHarEntry({ url: `${href}/api/v2/orders`, response }),
+    );
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual([
+      "/api/v2/clients",
+      "/api/v2/orders",
+    ]);
+  });
+
+  it("does not merge same-depth routes outside the proposed parameterised path", () => {
+    const representor = new Representor();
+    const response = createContent({ id: 1, name: "example" });
+    representor.upsert(
+      createHarEntry({ url: `${href}/api/v2/clients/109401`, response }),
+    );
+    representor.upsert(
+      createHarEntry({ url: `${href}/api/v2/orders/43685`, response }),
+    );
+    representor.upsert(
+      createHarEntry({ url: `${href}/api/v2/clients/125877`, response }),
+    );
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual([
+      "/api/v2/clients/{client}",
+      "/api/v2/orders/43685",
+    ]);
+  });
+
+  it("does not merge non-equivalent same-parent routes into a folded ID path", () => {
+    const representor = new Representor();
+    const clientResponse = createContent({ id: 1, name: "Example" });
+    const searchResponse = createContent({ results: [] });
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/clients/109401`,
+        response: clientResponse,
+      }),
+    );
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/clients/search`,
+        response: searchResponse,
+      }),
+    );
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/clients/125877`,
+        response: clientResponse,
+      }),
+    );
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual([
+      "/api/v2/clients/search",
+      "/api/v2/clients/{client}",
+    ]);
+  });
+
+  it("folds strong ID paths with compatible response shapes", () => {
+    const representor = new Representor();
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/orders/46068`,
+        response: createContent({
+          id: 46068,
+          status: "ready",
+          provider: { id: 1, name: "Provider" },
+          extra: null,
+        }),
+      }),
+    );
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/orders/49212`,
+        response: createContent({
+          id: 49212,
+          status: false,
+          provider: { id: 1, name: "Provider", logo: "logo.png" },
+          extra: { id: 7, title: "Additional" },
+        }),
+      }),
+    );
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual(["/api/v2/orders/{order}"]);
+  });
+
+  it("folds strong ID paths when observed URLs include query strings", () => {
+    const representor = new Representor();
+    const response = createContent({ id: 1, name: "Example" });
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/orders/46068?include=details`,
+        response,
+      }),
+    );
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/orders/49212?include=details`,
+        response,
+      }),
+    );
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual(["/api/v2/orders/{order}"]);
+  });
+
+  it("routes later ID examples with sparse optional branches into an existing dynamic path", () => {
+    const representor = new Representor();
+    const actionMaster = Object.fromEntries(
+      Array.from({ length: 15 }, (_, index) => [
+        `field_${index}`,
+        `value_${index}`,
+      ]),
+    );
+    const tariffOptionType = Object.fromEntries(
+      Array.from({ length: 18 }, (_, index) => [
+        `option_${index}`,
+        `value_${index}`,
+      ]),
+    );
+    const tariffResponse = {
+      title: "Tariff",
+      price: 100,
+      is_active: true,
+      provider: { id: 1, title: "Provider", website: "https://example.com" },
+    };
+
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/tariffs-proxy/3124278`,
+        response: createContent({
+          ...tariffResponse,
+          id: 3124278,
+          action_master: null,
+          tariff_options: [
+            {
+              id: 1,
+              value: "enabled",
+              tariff_option_type: tariffOptionType,
+            },
+          ],
+        }),
+      }),
+    );
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/tariffs-proxy/3865176`,
+        response: createContent({
+          ...tariffResponse,
+          id: 3865176,
+          action_master: null,
+          tariff_options: [
+            {
+              id: 2,
+              value: "disabled",
+              tariff_option_type: tariffOptionType,
+            },
+          ],
+        }),
+      }),
+    );
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/tariffs-proxy/3986544`,
+        response: createContent({
+          ...tariffResponse,
+          id: 3986544,
+          action_master: actionMaster,
+          tariff_options: [],
+        }),
+      }),
+    );
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual([
+      "/api/v2/tariffs-proxy/{tariffs-proxy}",
+    ]);
+  });
+
+  it("does not treat a tiny sparse strong ID shape as compatible with a richer shape", () => {
+    const representor = new Representor();
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/orders/46068`,
+        response: createContent({ id: 46068 }),
+      }),
+    );
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/orders/49212`,
+        response: createContent({
+          id: 49212,
+          status: "ready",
+          provider: { id: 1, name: "Provider" },
+        }),
+      }),
+    );
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual([
+      "/api/v2/orders/46068",
+      "/api/v2/orders/49212",
+    ]);
+  });
+
+  it("can disable compatible shape matching", () => {
+    const representor = new Representor({
+      parameterisation: { compatibleShape: false },
+    });
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/orders/46068`,
+        response: createContent({ id: 46068, status: "ready" }),
+      }),
+    );
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/orders/49212`,
+        response: createContent({ id: 49212, status: false }),
+      }),
+    );
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual([
+      "/api/v2/orders/46068",
+      "/api/v2/orders/49212",
+    ]);
+  });
+
+  it("can disable strong ID folding", () => {
+    const representor = new Representor({
+      parameterisation: { foldStrongIds: false },
+    });
+    const response = createContent({ id: 1, status: "ready" });
+    representor.upsert(
+      createHarEntry({ url: `${href}/api/v2/orders/46068`, response }),
+    );
+    representor.upsert(
+      createHarEntry({ url: `${href}/api/v2/orders/49212`, response }),
+    );
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual([
+      "/api/v2/orders/46068",
+      "/api/v2/orders/49212",
+    ]);
+  });
+
+  it("can disable text folding", () => {
+    const representor = new Representor({
+      parameterisation: { foldText: false },
+    });
+    const response = createContent({ id: 1, title: "Example" });
+    for (const slug of ["alpha", "beta", "gamma", "delta"]) {
+      representor.upsert(
+        createHarEntry({ url: `${href}/api/page/${slug}`, response }),
+      );
+    }
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual([
+      "/api/page/alpha",
+      "/api/page/beta",
+      "/api/page/delta",
+      "/api/page/gamma",
+    ]);
+  });
+
+  it("can disable automatic folding", () => {
+    const representor = new Representor({
+      parameterisation: { enabled: false },
+    });
+    const response = createContent({ id: 1, status: "ready" });
+    representor.upsert(
+      createHarEntry({ url: `${href}/api/v2/orders/46068`, response }),
+    );
+    representor.upsert(
+      createHarEntry({ url: `${href}/api/v2/orders/49212`, response }),
+    );
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual([
+      "/api/v2/orders/46068",
+      "/api/v2/orders/49212",
+    ]);
+  });
+
+  it("preserves parent endpoint data when child leaves are folded", () => {
+    const representor = new Representor();
+    const parentResponse = createContent({ total: 2 });
+    const childResponse = createContent({ id: 1, name: "Example" });
+    representor.upsert(
+      createHarEntry({ url: `${href}/a`, response: parentResponse }),
+    );
+    representor.upsert(
+      createHarEntry({ url: `${href}/a/1`, response: childResponse }),
+    );
+    representor.upsert(
+      createHarEntry({ url: `${href}/a/2`, response: childResponse }),
+    );
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual(["/a", "/a/{a}"]);
+    expect(paths["/a"]?.post?.responses?.["200"]?.content?.[mimeType]).toEqual(
+      expect.objectContaining({
+        example: { total: 2 },
+      }),
+    );
+  });
+
+  it("does not overwrite an existing folded ID path with an incompatible ID cluster", () => {
+    const representor = new Representor();
+    const clientResponse = createContent({ id: 1, name: "Example" });
+    const billingResponse = createContent({ id: 1, total: 100 });
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/clients/109401`,
+        response: clientResponse,
+      }),
+    );
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/clients/125877`,
+        response: clientResponse,
+      }),
+    );
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/clients/126364`,
+        response: billingResponse,
+      }),
+    );
+    representor.upsert(
+      createHarEntry({
+        url: `${href}/api/v2/clients/126365`,
+        response: billingResponse,
+      }),
+    );
+
+    const clientsNode =
+      representor.rest.data[host]!.childrenStatic["api"]!.childrenStatic["v2"]!
+        .childrenStatic["clients"]!;
+    expect(clientsNode.childrenDynamic).toHaveLength(1);
+    expect(Object.keys(clientsNode.childrenStatic).sort()).toEqual([
+      "126364",
+      "126365",
+    ]);
+    const dynamicResponseBody =
+      clientsNode.childrenDynamic[0]!.data?.methods[method]?.response?.[
+        "200"
+      ]?.[mimeType]?.body;
+    expect(dynamicResponseBody?.properties?.["name"]?.type).toBe("string");
+    expect(dynamicResponseBody?.properties?.["total"]).toBeUndefined();
+  });
+
+  it("does not collapse command names into a path parameter", () => {
+    const representor = new Representor();
+    const response = createContent({ ok: true });
+    representor.upsert(
+      createHarEntry({ url: `${href}/command/core/get-preference`, response }),
+    );
+    representor.upsert(
+      createHarEntry({ url: `${href}/command/core/set-preference`, response }),
+    );
+
+    const paths = representor.rest.generate().getSpec().paths || {};
+    expect(Object.keys(paths).sort()).toEqual([
+      "/command/core/get-preference",
+      "/command/core/set-preference",
+    ]);
   });
 });

--- a/packages/algorithm/src/parameterisation/automatic-parameterisation.ts
+++ b/packages/algorithm/src/parameterisation/automatic-parameterisation.ts
@@ -1,9 +1,6 @@
 import { negate } from "lodash";
 import { IrNode } from "../types/index.js";
-import {
-  isNodeDynamic,
-  matchDynamicChildren,
-} from "../utils/dynamic-children-helpers.js";
+import { isNodeDynamic, matchDynamicChildren } from "../utils/dynamic-children-helpers.js";
 import { parameterise } from "./parameterise.js";
 import { findAllMatches } from "./find-matches.js";
 import { isNodeDataEquivalent } from "./node-data-equivalence.js";
@@ -66,10 +63,7 @@ const getParameterisationCandidate = (
   };
 };
 
-const getParameterisedPathname = (
-  path1: string[],
-  path2: string[],
-): string[] => {
+const getParameterisedPathname = (path1: string[], path2: string[]): string[] => {
   const result: string[] = [];
   for (let i = 0; i < path1.length; i++) {
     if (path1[i] && path1[i] === path2[i]) {

--- a/packages/algorithm/src/parameterisation/automatic-parameterisation.ts
+++ b/packages/algorithm/src/parameterisation/automatic-parameterisation.ts
@@ -1,8 +1,20 @@
-import { negate, isEqual } from "lodash";
+import { negate } from "lodash";
 import { IrNode } from "../types/index.js";
-import { isNodeDynamic } from "../utils/dynamic-children-helpers.js";
+import {
+  isNodeDynamic,
+  matchDynamicChildren,
+} from "../utils/dynamic-children-helpers.js";
 import { parameterise } from "./parameterise.js";
 import { findAllMatches } from "./find-matches.js";
+import { isNodeDataEquivalent } from "./node-data-equivalence.js";
+import { isPartDynamic } from "./operations.js";
+import {
+  PathParameterisationOptions,
+  resolvePathParameterisationOptions,
+} from "./parameterisation-options.js";
+import { isStrongPathParameterValue } from "./path-parameter-values.js";
+
+const TEXT_PARAMETER_MIN_OCCURRENCES = 4;
 
 /**
  * Does a node or any of its parents have dynamic parts?
@@ -15,11 +27,49 @@ const hasDynamicParts = (node: IrNode): boolean => {
   return hasDynamicParts(node.parent);
 };
 
-const hasPartInCommon = (p1: string[], p2: string[]): boolean => {
-  return p1.some((part) => p2.includes(part));
+const hasPartInCommonAtSamePosition = (p1: string[], p2: string[]): boolean => {
+  return p1.some((part, idx) => part === p2[idx]);
 };
 
-const getParameterisedPathname = (path1: string[], path2: string[]): string[] => {
+const getDifferingPartIndexes = (p1: string[], p2: string[]): number[] => {
+  const result: number[] = [];
+  for (let i = 0; i < p1.length; i++) {
+    if (p1[i] !== p2[i]) {
+      result.push(i);
+    }
+  }
+  return result;
+};
+
+type ParameterisationCandidate = {
+  newPathname: string[];
+  strong: boolean;
+};
+
+const getParameterisationCandidate = (
+  pathname: string[],
+  matchPathname: string[],
+): ParameterisationCandidate | null => {
+  if (pathname.length !== matchPathname.length) return null;
+  if (!hasPartInCommonAtSamePosition(pathname, matchPathname)) return null;
+
+  const differingPartIndexes = getDifferingPartIndexes(pathname, matchPathname);
+  if (!differingPartIndexes.length) return null;
+
+  return {
+    newPathname: getParameterisedPathname(pathname, matchPathname),
+    strong: differingPartIndexes.every(
+      (idx) =>
+        isStrongPathParameterValue(pathname[idx]!) &&
+        isStrongPathParameterValue(matchPathname[idx]!),
+    ),
+  };
+};
+
+const getParameterisedPathname = (
+  path1: string[],
+  path2: string[],
+): string[] => {
   const result: string[] = [];
   for (let i = 0; i < path1.length; i++) {
     if (path1[i] && path1[i] === path2[i]) {
@@ -49,9 +99,48 @@ type Param = {
   rootNode: IrNode;
   // The method of the request
   method: string;
-  // The mime type of the request
+  // The response mime type
   mimeType: string;
-}
+  // The response status code
+  statusCode: string;
+  options?: Partial<PathParameterisationOptions>;
+};
+
+type MatchGroup = {
+  matches: IrNode[];
+  newPathname: string[];
+  strong: boolean;
+};
+
+const getDynamicPartCount = (pathname: string[]): number =>
+  pathname.filter(isPartDynamic).length;
+
+const hasExistingDynamicTarget = (
+  pathname: string[],
+  rootNode: IrNode,
+): boolean => {
+  let currentNode = rootNode;
+  let hasDynamicPart = false;
+
+  for (const part of pathname) {
+    if (isPartDynamic(part)) {
+      const dynamicChild = matchDynamicChildren(
+        part,
+        currentNode.childrenDynamic,
+      );
+      if (!dynamicChild) return false;
+      currentNode = dynamicChild;
+      hasDynamicPart = true;
+      continue;
+    }
+
+    const staticChild = currentNode.childrenStatic[part];
+    if (!staticChild) return false;
+    currentNode = staticChild;
+  }
+
+  return hasDynamicPart;
+};
 
 /**
  * Automatically parameterises similar paths in the OpenAPI IR tree
@@ -59,23 +148,94 @@ type Param = {
  * @param rootNode The root node of the IR tree
  */
 export const automaticParameterisation = (param: Param): void => {
-  const { pathname, insertedNode, rootNode, method, mimeType } = param;
+  const { pathname, insertedNode, rootNode, method, mimeType, statusCode } =
+    param;
+  const options = resolvePathParameterisationOptions(param.options);
+  if (!options.enabled) return;
   if (isNodeDynamic(insertedNode)) return;
-  const matches = findAllMatches(pathname, insertedNode, rootNode);
+  // Gather shape candidates first, then apply equivalence per candidate type.
+  // Strong IDs and text routes deliberately use different schema thresholds.
+  const matches = findAllMatches(pathname, insertedNode, rootNode, () => true);
   // Remove any matches that have path parameters
   // This means we never parameterise a path twice
   // The implementation identifies all parameters in one go
   const noDynamicParts = matches.filter(negate(hasDynamicParts));
-  // Heuristic: two paths must have the same number of parts, and at least one part in common
-  const partInCommon = noDynamicParts.filter((match) =>
-    hasPartInCommon(pathname, match.data?.mostRecentPathname.split("/") || []));
-  const excludingSelf = partInCommon.filter((match) => match.data?.mostRecentPathname !== insertedNode.data?.mostRecentPathname);
-  for (const match of excludingSelf) {
-    const matchData = match.data?.methods[method]?.request?.[mimeType]?.body;
-    const nodeData = insertedNode.data?.methods[method]?.request?.[mimeType]?.body;
-    if (isEqual(matchData, nodeData)) {
-      const newName = getParameterisedPathname(pathname, match.data?.mostRecentPathname.split("/").slice(1) || []);
-      parameterise(newName, insertedNode, rootNode);
+  const groups = new Map<string, MatchGroup>();
+  for (const match of noDynamicParts) {
+    if (
+      match.data?.mostRecentPathname === insertedNode.data?.mostRecentPathname
+    ) {
+      continue;
     }
+
+    const candidate = getParameterisationCandidate(
+      pathname,
+      match.data?.mostRecentPathname.split("/").slice(1) || [],
+    );
+    if (!candidate) {
+      continue;
+    }
+
+    if (candidate.strong && !options.foldStrongIds) {
+      continue;
+    }
+    if (!candidate.strong && !options.foldText) {
+      continue;
+    }
+    if (
+      !insertedNode.data ||
+      !match.data ||
+      !isNodeDataEquivalent(insertedNode.data, match.data, {
+        compatibleShape: options.compatibleShape,
+        mediaType: mimeType,
+        method,
+        mode: candidate.strong ? "strong-id" : "text",
+        statusCode,
+      })
+    ) {
+      continue;
+    }
+
+    // Group by the exact target template. This prevents a matching sibling from
+    // pulling in unrelated same-depth paths when only one cluster justified it.
+    const key = candidate.newPathname.join("\0");
+    const group = groups.get(key);
+    if (group) {
+      group.matches.push(match);
+      group.strong &&= candidate.strong;
+    } else {
+      groups.set(key, {
+        matches: [match],
+        newPathname: candidate.newPathname,
+        strong: candidate.strong,
+      });
+    }
+  }
+
+  const qualifyingGroups = Array.from(groups.values())
+    .filter(
+      (group) =>
+        // One dynamic child per parent means a second incompatible cluster at the
+        // same template would overwrite the first. Keep that cluster static.
+        !hasExistingDynamicTarget(group.newPathname, rootNode) &&
+        (group.strong ||
+          group.matches.length + 1 >= TEXT_PARAMETER_MIN_OCCURRENCES),
+    )
+    .sort((a, b) => {
+      if (a.strong !== b.strong) return a.strong ? -1 : 1;
+      if (a.matches.length !== b.matches.length) {
+        return b.matches.length - a.matches.length;
+      }
+      return (
+        getDynamicPartCount(a.newPathname) - getDynamicPartCount(b.newPathname)
+      );
+    });
+
+  const group = qualifyingGroups[0];
+  if (group) {
+    parameterise(group.newPathname, insertedNode, rootNode, [
+      insertedNode,
+      ...group.matches,
+    ]);
   }
 };

--- a/packages/algorithm/src/parameterisation/find-matches.ts
+++ b/packages/algorithm/src/parameterisation/find-matches.ts
@@ -1,6 +1,8 @@
 import { IrNode } from "../types/ir-graph.js";
-import { matchDynamicChildren } from "../utils/dynamic-children-helpers.js";
 import { areNodesEquivalent } from "./node-data-equivalence.js";
+import {
+  matchDynamicChildren
+} from "../utils/dynamic-children-helpers.js";
 import { isPartDynamic } from "./operations.js";
 
 /**
@@ -70,9 +72,13 @@ const dfs = (
     items.push(childDynamic);
   }
   for (const value of items) {
-    results.push(
-      ...dfs(pathname.slice(1), insertedNode, value, comparator, []),
-    );
+    results.push(...dfs(
+        pathname.slice(1),
+        insertedNode,
+        value,
+        comparator,
+        [],
+    ));
   }
   return results;
 };

--- a/packages/algorithm/src/parameterisation/find-matches.ts
+++ b/packages/algorithm/src/parameterisation/find-matches.ts
@@ -1,9 +1,7 @@
-import { intersection } from "lodash";
-import { areSchemasEqual } from 'genson-js';
 import { IrNode } from "../types/ir-graph.js";
-import {
-  matchDynamicChildren
-} from "../utils/dynamic-children-helpers.js";
+import { matchDynamicChildren } from "../utils/dynamic-children-helpers.js";
+import { areNodesEquivalent } from "./node-data-equivalence.js";
+import { isPartDynamic } from "./operations.js";
 
 /**
  * Find all matching nodes in the IR tree for a given pathname
@@ -12,7 +10,7 @@ import {
  *  - by comparator
  * The default comparator looks for equivalent request and response
  * schema for 2xx status codes of an endpoint
- * 
+ *
  * When () => true, all nodes of the same level are returned,
  * regardless of their data
  */
@@ -20,60 +18,24 @@ export const findAllMatches = (
   pathname: string[],
   insertedNode: IrNode,
   rootNode: IrNode,
-  comparator: (a: IrNode, b: IrNode) => boolean = isEquivalent,
+  comparator: (a: IrNode, b: IrNode) => boolean = areNodesEquivalent,
 ): IrNode[] => {
   return dfs(pathname, insertedNode, rootNode, comparator);
 };
 
 /**
- * Equivalence check for two nodes. Conditions:
- *  - Both nodes have a matching response, with the same method, status code, and mime type
- *  - This response and its request is equal in dest and src
- * @param dest The existing node
- * @param src The new node we wish to merge
+ * Find nodes that match the static/dynamic shape of a pathname.
+ * Static parts match the same static child or an existing dynamic child, while
+ * dynamic parts match any child at that level. This is used when applying a
+ * known parameterised path.
  */
-const isEquivalent = (dest: IrNode, src: IrNode): boolean => {
-  // Confirm methods exist
-  if (!dest.data?.methods || !src.data?.methods) {
-    return false;
-  }
-  const methodsIntersect = intersection(Object.keys(dest.data.methods), Object.keys(src.data.methods));
-  // Confirm that both nodes have at least one matching method
-  if (!methodsIntersect.length) {
-    return false;
-  }
-
-  for (const method of methodsIntersect) {
-    const endpointDest = dest.data.methods[method];
-    const endpointSrc = src.data.methods[method];
-    if (!endpointDest?.response || !endpointSrc?.response) {
-      return false;
-    }
-    for (const statusCode of Object.keys(endpointSrc.response)) {
-      for (const mediaType of Object.keys(endpointSrc.response[statusCode] || [])) {
-        const responseDestBody = endpointDest.response[statusCode]?.[mediaType]?.body;
-        const responseSrcBody = endpointSrc.response[statusCode]?.[mediaType]?.body;
-        // Check for undefined, which is not a JSON primitive and indicates no observed data
-        // Whereas null is a valid JSON response that may define an endpoint
-        if (!responseDestBody || !responseSrcBody) {
-          continue;
-        }
-        // If the responses are equal, verify the request is also equal. If so, it is a match
-        if (areSchemasEqual(responseDestBody, responseSrcBody)) {
-          if (!endpointDest.request || !endpointSrc.request) {
-            return true;
-          }
-          const requestDestBody = endpointDest.request[mediaType]?.body;
-          const requestSrcBody = endpointSrc.request[mediaType]?.body;
-          if (requestDestBody && requestSrcBody && areSchemasEqual(requestDestBody, requestSrcBody)) {
-            return true;
-          }
-        }
-      }
-    }
-  }
-
-  return false;
+export const findPathMatches = (
+  pathname: string[],
+  insertedNode: IrNode,
+  rootNode: IrNode,
+  comparator: (a: IrNode, b: IrNode) => boolean = areNodesEquivalent,
+): IrNode[] => {
+  return dfsPath(pathname, insertedNode, rootNode, comparator);
 };
 
 const dfs = (
@@ -108,14 +70,60 @@ const dfs = (
     items.push(childDynamic);
   }
   for (const value of items) {
-    results.push(...dfs(
-      pathname.slice(1),
-      insertedNode,
-      value,
-      comparator,
-      [],
-    ));
+    results.push(
+      ...dfs(pathname.slice(1), insertedNode, value, comparator, []),
+    );
   }
   return results;
 };
 
+const getPatternChildren = (part: string, currentNode: IrNode): IrNode[] => {
+  if (isPartDynamic(part)) {
+    return [
+      ...Object.values(currentNode.childrenStatic),
+      ...currentNode.childrenDynamic,
+    ];
+  }
+
+  const children: IrNode[] = [];
+  const staticChild = currentNode.childrenStatic[part];
+  if (staticChild) {
+    children.push(staticChild);
+  }
+  const dynamicChild = matchDynamicChildren(part, currentNode.childrenDynamic);
+  if (dynamicChild) {
+    children.push(dynamicChild);
+  }
+  return children;
+};
+
+const dfsPath = (
+  pathname: string[],
+  insertedNode: IrNode,
+  currentNode: IrNode,
+  comparator: (a: IrNode, b: IrNode) => boolean,
+  results: IrNode[] = [],
+): IrNode[] => {
+  if (pathname.length === 0) {
+    return results;
+  }
+
+  const part = pathname[0]!;
+  const children = getPatternChildren(part, currentNode);
+  const isLast = pathname.length === 1;
+  if (isLast) {
+    for (const leaf of children) {
+      if (comparator(insertedNode, leaf)) {
+        results.push(leaf);
+      }
+    }
+    return results;
+  }
+
+  for (const value of children) {
+    results.push(
+      ...dfsPath(pathname.slice(1), insertedNode, value, comparator, []),
+    );
+  }
+  return results;
+};

--- a/packages/algorithm/src/parameterisation/index.ts
+++ b/packages/algorithm/src/parameterisation/index.ts
@@ -1,1 +1,2 @@
-export * from "./automatic-parameterisation.js"
+export * from "./automatic-parameterisation.js";
+export * from "./parameterisation-options.js";

--- a/packages/algorithm/src/parameterisation/node-data-equivalence.ts
+++ b/packages/algorithm/src/parameterisation/node-data-equivalence.ts
@@ -1,0 +1,103 @@
+import { areSchemasEqual } from "genson-js";
+import { intersection } from "lodash";
+import { IrNode, NodeData } from "../types/index.js";
+import { areSchemasShapeCompatible } from "./schema-shape-compatibility.js";
+
+type NodeDataEquivalenceOptions = {
+  compatibleShape?: boolean;
+  mediaType?: string;
+  method?: string;
+  mode?: "established" | "strong-id" | "text";
+  statusCode?: string;
+};
+
+const areBodiesEquivalent = (
+  destBody: Parameters<typeof areSchemasEqual>[0] | undefined,
+  srcBody: Parameters<typeof areSchemasEqual>[0] | undefined,
+  options: NodeDataEquivalenceOptions,
+): boolean => {
+  if (!destBody || !srcBody) return false;
+  if (options.mode === "text") {
+    // Text routes are the riskiest false-positive source. Keep their safety
+    // vetoes active even when compatible-shape widening is disabled, while
+    // still requiring exact equality in that stricter mode.
+    const textShapeSafe = areSchemasShapeCompatible(destBody, srcBody, "text");
+    return options.compatibleShape
+      ? textShapeSafe
+      : areSchemasEqual(destBody, srcBody) && textShapeSafe;
+  }
+  if (areSchemasEqual(destBody, srcBody)) return true;
+  return Boolean(
+    options.compatibleShape &&
+      areSchemasShapeCompatible(destBody, srcBody, options.mode || "text"),
+  );
+};
+
+const areRequestsEquivalent = (
+  destRequestBody: Parameters<typeof areSchemasEqual>[0] | undefined,
+  srcRequestBody: Parameters<typeof areSchemasEqual>[0] | undefined,
+): boolean => {
+  if (!destRequestBody && !srcRequestBody) return true;
+  if (!destRequestBody || !srcRequestBody) return false;
+  return areSchemasEqual(destRequestBody, srcRequestBody);
+};
+
+export const isNodeDataEquivalent = (
+  dest: NodeData,
+  src: NodeData,
+  options: NodeDataEquivalenceOptions = {},
+): boolean => {
+  const methodsIntersect = options.method
+    ? intersection(
+        [options.method],
+        Object.keys(dest.methods),
+        Object.keys(src.methods),
+      )
+    : intersection(Object.keys(dest.methods), Object.keys(src.methods));
+  if (!methodsIntersect.length) {
+    return false;
+  }
+
+  for (const method of methodsIntersect) {
+    const endpointDest = dest.methods[method];
+    const endpointSrc = src.methods[method];
+    if (!endpointDest?.response || !endpointSrc?.response) {
+      return false;
+    }
+    const statusCodes = options.statusCode
+      ? [options.statusCode]
+      : Object.keys(endpointSrc.response);
+    for (const statusCode of statusCodes) {
+      // Automatic folding compares the concrete observation's response slot.
+      // Without this, a path could fold because of another status/media variant.
+      const mediaTypes = options.mediaType
+        ? [options.mediaType]
+        : Object.keys(endpointSrc.response[statusCode] || []);
+      for (const mediaType of mediaTypes) {
+        const responseDestBody =
+          endpointDest.response[statusCode]?.[mediaType]?.body;
+        const responseSrcBody =
+          endpointSrc.response[statusCode]?.[mediaType]?.body;
+
+        if (!areBodiesEquivalent(responseDestBody, responseSrcBody, options)) {
+          continue;
+        }
+
+        const requestDestBody = endpointDest.request?.[mediaType]?.body;
+        const requestSrcBody = endpointSrc.request?.[mediaType]?.body;
+        if (areRequestsEquivalent(requestDestBody, requestSrcBody)) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+};
+
+export const areNodesEquivalent = (dest: IrNode, src: IrNode): boolean => {
+  if (!dest.data || !src.data) {
+    return false;
+  }
+  return isNodeDataEquivalent(dest.data, src.data);
+};

--- a/packages/algorithm/src/parameterisation/operations.ts
+++ b/packages/algorithm/src/parameterisation/operations.ts
@@ -40,7 +40,7 @@ const removeEmptyNodes = (node: IrNode): void => {
     if (isNodeDynamic(node)) {
       node.parent.childrenDynamic = removeDynamicChild(
         node.key,
-        node.parent.childrenDynamic,
+        node.parent.childrenDynamic
       );
     }
     removeEmptyNodes(node.parent);
@@ -54,11 +54,7 @@ export const isPartDynamic = (part: string) =>
  * Inserts node at position pathname into intoNode
  * Creates nodes along its path if necessary
  */
-export const insertNode = (
-  pathname: string[],
-  node: IrNode,
-  intoNode: IrNode,
-): void => {
+export const insertNode = (pathname: string[], node: IrNode, intoNode: IrNode): void => {
   if (pathname.length === 0) {
     return;
   }
@@ -67,7 +63,7 @@ export const insertNode = (
   if (isPartDynamic(part)) {
     const dynamicChildExists = matchDynamicChildren(
       part,
-      intoNode.childrenDynamic,
+      intoNode.childrenDynamic
     );
     if (dynamicChildExists) {
       if (isLast) {

--- a/packages/algorithm/src/parameterisation/operations.ts
+++ b/packages/algorithm/src/parameterisation/operations.ts
@@ -11,7 +11,7 @@ import { NodeData } from "../types/index.js";
 /**
  * Remove nodes by removing their key from the parent
  * Remove data from the node
- * Keep when they have children
+ * Keep when they have data or children
  * Returns a list of every data entry in nodes that was removed
  */
 export const removeNodes = (nodes: IrNode[]): Array<NodeData> => {
@@ -30,7 +30,7 @@ const removeEmptyNodes = (node: IrNode): void => {
   const hasStaticChildren = Object.keys(node.childrenStatic).length > 0;
   const hasDynamicChildren = node.childrenDynamic.length > 0;
   const hasChildren = hasStaticChildren || hasDynamicChildren;
-  if (hasChildren) {
+  if (node.data || hasChildren) {
     return;
   }
   if (node.parent) {
@@ -40,7 +40,7 @@ const removeEmptyNodes = (node: IrNode): void => {
     if (isNodeDynamic(node)) {
       node.parent.childrenDynamic = removeDynamicChild(
         node.key,
-        node.parent.childrenDynamic
+        node.parent.childrenDynamic,
       );
     }
     removeEmptyNodes(node.parent);
@@ -54,7 +54,11 @@ export const isPartDynamic = (part: string) =>
  * Inserts node at position pathname into intoNode
  * Creates nodes along its path if necessary
  */
-export const insertNode = (pathname: string[], node: IrNode, intoNode: IrNode): void => {
+export const insertNode = (
+  pathname: string[],
+  node: IrNode,
+  intoNode: IrNode,
+): void => {
   if (pathname.length === 0) {
     return;
   }
@@ -63,7 +67,7 @@ export const insertNode = (pathname: string[], node: IrNode, intoNode: IrNode): 
   if (isPartDynamic(part)) {
     const dynamicChildExists = matchDynamicChildren(
       part,
-      intoNode.childrenDynamic
+      intoNode.childrenDynamic,
     );
     if (dynamicChildExists) {
       if (isLast) {

--- a/packages/algorithm/src/parameterisation/operations.ts
+++ b/packages/algorithm/src/parameterisation/operations.ts
@@ -76,6 +76,7 @@ export const insertNode = (
       return insertNode(pathname.slice(1), node, dynamicChildExists);
     } else {
       const child = isLast ? node : createDynamicChild(part, intoNode);
+      child.key = part;
       intoNode.childrenDynamic.push(child);
       child.parent = intoNode;
       return insertNode(pathname.slice(1), node, child);
@@ -89,6 +90,7 @@ export const insertNode = (
       return insertNode(pathname.slice(1), node, staticChildExists);
     } else {
       const child = isLast ? node : createNode({ key: part, parent: intoNode });
+      child.key = part;
       intoNode.childrenStatic[part] = child;
       child.parent = intoNode;
       return insertNode(pathname.slice(1), node, child);

--- a/packages/algorithm/src/parameterisation/parameterisation-options.ts
+++ b/packages/algorithm/src/parameterisation/parameterisation-options.ts
@@ -1,0 +1,45 @@
+export type PathParameterisationMode = "off" | "id-only" | "safe-text";
+
+export type PathParameterisationOptions = {
+  enabled: boolean;
+  foldStrongIds: boolean;
+  foldText: boolean;
+  compatibleShape: boolean;
+};
+
+export const defaultPathParameterisationOptions: PathParameterisationOptions = {
+  enabled: true,
+  foldStrongIds: true,
+  foldText: true,
+  compatibleShape: true,
+};
+
+export const resolvePathParameterisationOptions = (
+  options: Partial<PathParameterisationOptions> = {},
+): PathParameterisationOptions => ({
+  ...defaultPathParameterisationOptions,
+  ...options,
+});
+
+export const pathParameterisationOptionsFromMode = (
+  mode: PathParameterisationMode,
+): PathParameterisationOptions => {
+  if (mode === "off") {
+    return {
+      ...defaultPathParameterisationOptions,
+      enabled: false,
+    };
+  }
+  if (mode === "id-only") {
+    return {
+      ...defaultPathParameterisationOptions,
+      foldText: false,
+    };
+  }
+  return defaultPathParameterisationOptions;
+};
+
+export const isPathParameterisationMode = (
+  mode: string,
+): mode is PathParameterisationMode =>
+  mode === "off" || mode === "id-only" || mode === "safe-text";

--- a/packages/algorithm/src/parameterisation/parameterise.test.ts
+++ b/packages/algorithm/src/parameterisation/parameterise.test.ts
@@ -41,11 +41,11 @@ describe("parameterise", () => {
       representor.rest.data[host]!.childrenStatic["a"]!.childrenStatic["b"]!,
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/c`, request: request1 }),
+      createHarEntry({ url: `${href}/a/c`, request: request1 })
     );
     const parameterisePathname = ["a", "{dynamic}"];
     representor.upsert(
-      createHarEntry({ url: `${href}/a/b/c`, request: request1 }),
+      createHarEntry({ url: `${href}/a/b/c`, request: request1 })
     );
     representor.upsert(createHarEntry({ url: `${href}/a`, request: request2 }));
     representor.upsert(createHarEntry({ url: `${href}/a`, request: request1 }));
@@ -59,7 +59,7 @@ describe("parameterise", () => {
     expect(Object.values(node.parent!.childrenStatic)).toHaveLength(1);
     expect(
       node.parent?.data?.methods?.[method]?.request?.[mimeType]?.body
-        ?.properties?.["test"]?.type,
+        ?.properties?.["test"]?.type
     ).toEqual(["boolean", "integer"]);
     const reqBodyTypes =
       node.data?.methods?.[method]?.request?.[mimeType]?.body?.properties?.[

--- a/packages/algorithm/src/parameterisation/parameterise.test.ts
+++ b/packages/algorithm/src/parameterisation/parameterise.test.ts
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from "lodash";
 import { describe, test, expect } from "vitest";
 import { parameterise } from "./parameterise.js";
 import { Representor } from "../representor.js";
@@ -17,7 +17,7 @@ describe("parameterise", () => {
     representor.upsert(createHarEntry({ url: `${href}/a`, request }));
     representor.upsert(createHarEntry({ url: `${href}/b`, request }));
     const parameterisePathname = ["{dynamic}"];
-    const compareTo = representor.rest.data[host]?.childrenStatic["a"]!;
+    const compareTo = representor.rest.data[host]!.childrenStatic["a"]!;
     parameterise(parameterisePathname, compareTo, representor.rest.data[host]!);
     const node: IrNode = representor.rest.data[host]!.childrenDynamic[0]!;
     representor.upsert(createHarEntry({ url: `${href}/b`, request }));
@@ -35,15 +35,18 @@ describe("parameterise", () => {
     const request1 = createContent({ test: 1 });
     const request2 = createContent({ test: false });
     representor.upsert(
-      createHarEntry({ url: `${href}/a/b`, request: request1 })
+      createHarEntry({ url: `${href}/a/b`, request: request1 }),
     );
-    const compareTo = cloneDeep(representor.rest.data[host]!.childrenStatic["a"]!.childrenStatic["b"]!);
+    const compareTo = cloneDeep(
+      representor.rest.data[host]!.childrenStatic["a"]!.childrenStatic["b"]!,
+    );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/c`, request: request1 })
+      createHarEntry({ url: `${href}/a/c`, request: request1 }),
     );
     const parameterisePathname = ["a", "{dynamic}"];
-    const data = representor.rest.data[host]!.childrenStatic["a"]!;
-    representor.upsert(createHarEntry({ url: `${href}/a/b/c`, request: request1 }));
+    representor.upsert(
+      createHarEntry({ url: `${href}/a/b/c`, request: request1 }),
+    );
     representor.upsert(createHarEntry({ url: `${href}/a`, request: request2 }));
     representor.upsert(createHarEntry({ url: `${href}/a`, request: request1 }));
     parameterise(parameterisePathname, compareTo, representor.rest.data[host]!);
@@ -56,7 +59,7 @@ describe("parameterise", () => {
     expect(Object.values(node.parent!.childrenStatic)).toHaveLength(1);
     expect(
       node.parent?.data?.methods?.[method]?.request?.[mimeType]?.body
-        ?.properties?.["test"]?.type
+        ?.properties?.["test"]?.type,
     ).toEqual(["boolean", "integer"]);
     const reqBodyTypes =
       node.data?.methods?.[method]?.request?.[mimeType]?.body?.properties?.[

--- a/packages/algorithm/src/parameterisation/parameterise.ts
+++ b/packages/algorithm/src/parameterisation/parameterise.ts
@@ -1,5 +1,8 @@
 import { IrNode } from "../types/index.js";
-import { insertNode, removeNodes } from "./operations.js";
+import {
+  insertNode,
+  removeNodes,
+} from "./operations.js";
 import { setPathParameterNames } from "./set-path-parameter-names.js";
 import { findPathMatches } from "./find-matches.js";
 import { mergeNodeData } from "../update-or-create/merge-node-data.js";

--- a/packages/algorithm/src/parameterisation/parameterise.ts
+++ b/packages/algorithm/src/parameterisation/parameterise.ts
@@ -1,22 +1,30 @@
 import { IrNode } from "../types/index.js";
-import {
-  insertNode,
-  removeNodes,
-} from "./operations.js";
+import { insertNode, removeNodes } from "./operations.js";
 import { setPathParameterNames } from "./set-path-parameter-names.js";
-import { findAllMatches } from "./find-matches.js";
+import { findPathMatches } from "./find-matches.js";
 import { mergeNodeData } from "../update-or-create/merge-node-data.js";
 import { createNode } from "../utils/node-creation.js";
 
-export const parameterise = (newPathname: string[], insertedNode: IrNode, rootNode: IrNode): void => {
+export const parameterise = (
+  newPathname: string[],
+  insertedNode: IrNode,
+  rootNode: IrNode,
+  nodesToParameterise: IrNode[] = findPathMatches(
+    newPathname,
+    insertedNode,
+    rootNode,
+    () => true,
+  ),
+): void => {
   // Get all matching nodes, e.g. /a/{b} matches /a/c, /a/d, /a/[...]
   // Including nodes that have different data, as they are still considered
   // to be the same node
-  const matches = findAllMatches(newPathname, insertedNode, rootNode, () => true);
-  const removedData = removeNodes(matches).reduce(mergeNodeData);
+  const removedNodeData = removeNodes(nodesToParameterise);
+  if (!removedNodeData.length) return;
+  const removedData = removedNodeData.reduce(mergeNodeData);
   const newNode = createNode({ data: removedData });
   if (newNode) {
     insertNode(newPathname, newNode, rootNode);
-    setPathParameterNames(newNode, matches);
+    setPathParameterNames(newNode, nodesToParameterise);
   }
 };

--- a/packages/algorithm/src/parameterisation/path-parameter-values.ts
+++ b/packages/algorithm/src/parameterisation/path-parameter-values.ts
@@ -1,0 +1,16 @@
+const isVersionLike = (part: string): boolean =>
+  /^(v|version|api[-_]?v|rest_v)\d+([._-]\d+)*$/i.test(part);
+
+export const isStrongPathParameterValue = (part: string): boolean => {
+  if (isVersionLike(part)) return false;
+  if (/^\d+$/.test(part)) return true;
+  if (
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      part,
+    )
+  ) {
+    return true;
+  }
+  if (/^[0-9a-f]{12,}$/i.test(part)) return true;
+  return /^(?=.*\d)[A-Za-z0-9]{8,}$/.test(part);
+};

--- a/packages/algorithm/src/parameterisation/schema-shape-compatibility.test.ts
+++ b/packages/algorithm/src/parameterisation/schema-shape-compatibility.test.ts
@@ -1,0 +1,145 @@
+import { createSchema } from "genson-js";
+import { describe, expect, it } from "vitest";
+import { areSchemasShapeCompatible } from "./schema-shape-compatibility.js";
+
+const schema = (value: unknown) => createSchema(value);
+
+describe("areSchemasShapeCompatible", () => {
+  it("treats null object branches as neutral instead of missing descendants", () => {
+    const sparse = schema({
+      id: 1,
+      title: "Example",
+      price: 100,
+      active: true,
+      provider: null,
+    });
+    const populated = schema({
+      id: 2,
+      title: "Other",
+      price: 200,
+      active: false,
+      provider: Object.fromEntries(
+        Array.from({ length: 150 }, (_, index) => [
+          `field_${index}`,
+          `value_${index}`,
+        ]),
+      ),
+    });
+
+    expect(areSchemasShapeCompatible(sparse, populated, "established")).toBe(
+      true,
+    );
+  });
+
+  it("treats empty array item shape as neutral", () => {
+    const empty = schema({
+      id: 1,
+      title: "Example",
+      options: [],
+    });
+    const populated = schema({
+      id: 2,
+      title: "Other",
+      options: [
+        {
+          id: 1,
+          value: "enabled",
+          option: { id: 1, title: "Router" },
+        },
+      ],
+    });
+
+    expect(areSchemasShapeCompatible(empty, populated, "strong-id")).toBe(true);
+  });
+
+  it("treats empty object shape as neutral", () => {
+    const empty = schema({
+      id: 1,
+      title: "Example",
+      metadata: {},
+    });
+    const populated = schema({
+      id: 2,
+      title: "Other",
+      metadata: {
+        priority: 10,
+        owner: { id: 1, name: "Alice" },
+      },
+    });
+
+    expect(areSchemasShapeCompatible(empty, populated, "strong-id")).toBe(true);
+  });
+
+  it("does not treat a neutral null branch as positive text-route evidence", () => {
+    const sparse = schema({
+      id: 1,
+      provider: null,
+    });
+    const populated = schema({
+      id: 2,
+      provider: { id: 1, title: "Provider" },
+    });
+
+    expect(areSchemasShapeCompatible(sparse, populated, "text")).toBe(false);
+  });
+
+  it("requires observed field overlap for strong ID shape compatibility", () => {
+    expect(
+      areSchemasShapeCompatible(
+        schema({ id: null }),
+        schema({ id: 2 }),
+        "strong-id",
+      ),
+    ).toBe(false);
+  });
+
+  it("requires observed field overlap for established shape compatibility", () => {
+    expect(
+      areSchemasShapeCompatible(
+        schema({ provider: null }),
+        schema({ provider: { id: 1, title: "Provider" } }),
+        "established",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects array versus object container conflicts", () => {
+    expect(
+      areSchemasShapeCompatible(
+        schema({ id: 1, values: [] }),
+        schema({ id: 2, values: {} }),
+        "established",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects array item kind conflicts", () => {
+    expect(
+      areSchemasShapeCompatible(
+        schema({ id: 1, values: [{ id: 1 }] }),
+        schema({ id: 2, values: ["one"] }),
+        "established",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects scalar versus object conflicts", () => {
+    expect(
+      areSchemasShapeCompatible(
+        schema({ id: 1, provider: "unknown" }),
+        schema({ id: 2, provider: { id: 1 } }),
+        "established",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps scalar primitive variations compatible", () => {
+    expect(
+      areSchemasShapeCompatible(
+        schema({ id: 1, status: "ready" }),
+        schema({ id: 2, status: false }),
+        "strong-id",
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/algorithm/src/parameterisation/schema-shape-compatibility.ts
+++ b/packages/algorithm/src/parameterisation/schema-shape-compatibility.ts
@@ -1,0 +1,254 @@
+import { Schema } from "genson-js";
+
+type ShapeKind = "array" | "object" | "scalar" | "unknown";
+
+type ShapeMode = "established" | "strong-id" | "text";
+
+type ShapeScore = {
+  compatibleCommon: number;
+  conflicts: number;
+  largerCoverage: number;
+  smallerCoverage: number;
+  smallerSize: number;
+};
+
+const COMMON_COLLECTION_KEYS = new Set([
+  "count",
+  "next",
+  "previous",
+  "results",
+]);
+
+const getSchemaTypes = (schema: Schema | undefined): string[] => {
+  const type = schema?.type;
+  if (!type) {
+    if (schema?.properties) return ["object"];
+    if (schema?.items) return ["array"];
+    return [];
+  }
+  return Array.isArray(type) ? type : [type];
+};
+
+const getShapeKind = (schema: Schema | undefined): ShapeKind => {
+  const nonNullTypes = getSchemaTypes(schema).filter((type) => type !== "null");
+  if (!nonNullTypes.length) return "unknown";
+  if (nonNullTypes.includes("object")) return "object";
+  if (nonNullTypes.includes("array")) return "array";
+  return "scalar";
+};
+
+const areKindsCompatible = (left: ShapeKind, right: ShapeKind): boolean => {
+  if (left === "unknown" || right === "unknown") return true;
+  if (left === right) return true;
+  // Scalar values are intentionally grouped together. Captured examples often
+  // disagree on string/number/boolean while still describing one route.
+  return left === "scalar" && right === "scalar";
+};
+
+type ShapePath = {
+  kind: ShapeKind;
+  sparse: boolean;
+};
+
+const isSparseContainer = (schema: Schema | undefined): boolean => {
+  // These shapes tell us the branch exists, but not what is inside it.
+  const kind = getShapeKind(schema);
+  if (kind === "unknown") return true;
+  if (kind === "object") return !Object.keys(schema?.properties || {}).length;
+  if (kind === "array") return !schema?.items;
+  return false;
+};
+
+const getParentPath = (path: string): string | null => {
+  if (path === "$") return null;
+  if (path.endsWith("[]")) {
+    const parent = path.slice(0, -2);
+    return parent === "$" ? null : parent;
+  }
+  const lastDotIndex = path.lastIndexOf(".");
+  if (lastDotIndex <= 0) return null;
+  return path.slice(0, lastDotIndex);
+};
+
+// Sparse/null ancestors mean "not observed inside this branch", not "missing".
+// Their descendants should not reduce coverage on the sparse side.
+const hasSparseAncestor = (
+  paths: Map<string, ShapePath>,
+  path: string,
+): boolean => {
+  let parentPath = getParentPath(path);
+  while (parentPath) {
+    if (paths.get(parentPath)?.sparse) return true;
+    parentPath = getParentPath(parentPath);
+  }
+  return false;
+};
+
+const isKnownKind = (kind: ShapeKind): boolean => kind !== "unknown";
+
+// Null/unknown is not positive evidence for a field's shape.
+const isCommonPathNeutral = (left: ShapePath, right: ShapePath): boolean =>
+  !isKnownKind(left.kind) || !isKnownKind(right.kind);
+
+// Flatten nested schemas to structural locations so optional populated branches
+// can be compared against sparse/null examples without requiring exact equality.
+const collectShapePaths = (
+  schema: Schema | undefined,
+  prefix = "$",
+  paths = new Map<string, ShapePath>(),
+): Map<string, ShapePath> => {
+  if (!schema) return paths;
+
+  for (const [key, value] of Object.entries(schema.properties || {})) {
+    const path = `${prefix}.${key}`;
+    paths.set(path, {
+      kind: getShapeKind(value),
+      sparse: isSparseContainer(value),
+    });
+    collectShapePaths(value, path, paths);
+  }
+
+  if (schema.items) {
+    const path = `${prefix}[]`;
+    paths.set(path, {
+      kind: getShapeKind(schema.items),
+      sparse: isSparseContainer(schema.items),
+    });
+    collectShapePaths(schema.items, path, paths);
+  }
+
+  return paths;
+};
+
+const getShapeScore = (left: Schema, right: Schema): ShapeScore => {
+  const leftPaths = collectShapePaths(left);
+  const rightPaths = collectShapePaths(right);
+  const leftKeys = new Set(leftPaths.keys());
+  const rightKeys = new Set(rightPaths.keys());
+  let leftComparable = 0;
+  let rightComparable = 0;
+  let compatibleCommon = 0;
+  let conflicts = 0;
+
+  for (const key of leftKeys) {
+    const leftPath = leftPaths.get(key)!;
+    const rightPath = rightPaths.get(key);
+    if (!rightPath) {
+      if (!hasSparseAncestor(rightPaths, key)) leftComparable++;
+      continue;
+    }
+
+    if (isCommonPathNeutral(leftPath, rightPath)) {
+      continue;
+    }
+
+    leftComparable++;
+    rightComparable++;
+    if (areKindsCompatible(leftPath.kind, rightPath.kind)) {
+      compatibleCommon++;
+    } else {
+      conflicts++;
+    }
+  }
+
+  for (const key of rightKeys) {
+    if (leftKeys.has(key)) continue;
+    if (!hasSparseAncestor(leftPaths, key)) rightComparable++;
+  }
+
+  const smallerSize = Math.min(leftComparable, rightComparable);
+  const largerSize = Math.max(leftComparable, rightComparable);
+
+  return {
+    compatibleCommon,
+    conflicts,
+    largerCoverage: largerSize ? compatibleCommon / largerSize : 1,
+    smallerCoverage: smallerSize ? compatibleCommon / smallerSize : 1,
+    smallerSize,
+  };
+};
+
+const hasCompatibleRootKind = (left: Schema, right: Schema): boolean =>
+  areKindsCompatible(getShapeKind(left), getShapeKind(right));
+
+const isSparseGenericCollection = (schema: Schema): boolean => {
+  if (getShapeKind(schema) !== "object") return false;
+  const properties = schema.properties || {};
+  const keys = Object.keys(properties);
+  if (!keys.length || !keys.every((key) => COMMON_COLLECTION_KEYS.has(key))) {
+    return false;
+  }
+  const results = properties["results"];
+  return Boolean(
+    results && getShapeKind(results) === "array" && !results.items,
+  );
+};
+
+const isStrongIdShapeCompatible = (score: ShapeScore): boolean => {
+  if (score.compatibleCommon === 0) return false;
+  if (score.smallerSize < 8) {
+    // ID-looking path values are strong route evidence, but avoid the degenerate
+    // one-field subset case where `{ id }` would match nearly every object.
+    return (
+      score.compatibleCommon >= 2 &&
+      score.smallerCoverage >= 0.9 &&
+      (score.largerCoverage >= 0.6 || score.compatibleCommon >= 4)
+    );
+  }
+  return score.smallerCoverage >= 0.9 && score.largerCoverage >= 0.6;
+};
+
+const isTextShapeCompatible = (
+  left: Schema,
+  right: Schema,
+  score: ShapeScore,
+): boolean => {
+  // Empty collection wrappers repeat across unrelated resources such as clients,
+  // orders, and leads, so they are not enough evidence for textual routes.
+  if (isSparseGenericCollection(left) && isSparseGenericCollection(right)) {
+    return false;
+  }
+  if (score.smallerSize < 2) return false;
+  if (score.smallerSize < 8) {
+    if (score.smallerCoverage === 1 && score.largerCoverage === 1) {
+      return true;
+    }
+    return (
+      score.compatibleCommon >= 3 &&
+      score.smallerCoverage >= 0.9 &&
+      score.largerCoverage >= 0.6
+    );
+  }
+  return score.smallerCoverage >= 0.9 && score.largerCoverage >= 0.8;
+};
+
+const isEstablishedShapeCompatible = (score: ShapeScore): boolean => {
+  if (score.compatibleCommon === 0) return false;
+  if (score.smallerSize < 8) {
+    return score.smallerCoverage >= 0.9 && score.largerCoverage >= 0.8;
+  }
+  return score.smallerCoverage >= 0.9 && score.largerCoverage >= 0.6;
+};
+
+export const areSchemasShapeCompatible = (
+  left: Schema,
+  right: Schema,
+  mode: ShapeMode,
+): boolean => {
+  if (!hasCompatibleRootKind(left, right)) return false;
+  const score = getShapeScore(left, right);
+
+  // Observed object/array/scalar kind conflicts are hard stops. Sparse/null
+  // branches are made neutral before this point, so remaining conflicts are real.
+  if (score.conflicts > 0) {
+    return false;
+  }
+
+  if (mode === "strong-id") {
+    return isStrongIdShapeCompatible(score);
+  }
+  if (mode === "text") {
+    return isTextShapeCompatible(left, right, score);
+  }
+  return isEstablishedShapeCompatible(score);
+};

--- a/packages/algorithm/src/representor-rest.test.ts
+++ b/packages/algorithm/src/representor-rest.test.ts
@@ -71,7 +71,7 @@ describe("generation following upsert of REST HAR entries", () => {
     expect(result.getSpec().info.title).toBe("OpenAPI Specification");
     expect(result.getSpec().info.version).toBe("1.0.0");
     expect(result.getSpec().info.description).toBe(
-      "A specification for www.example.com",
+      "A specification for www.example.com"
     );
     expect(result.getSpec().paths).toBeDefined();
   });
@@ -126,7 +126,7 @@ describe("generation following upsert of REST HAR entries", () => {
   });
 });
 
-describe("edge cases", () => {
+describe('edge cases', () => {
   it("handles cases where the har method is uppercase and lowercase", async () => {
     const representor = new Representor();
     const entry1 = createHarEntry(createResponse(simpleJsonA));
@@ -206,24 +206,23 @@ describe("upsert and automatic parameterisation integration tests", () => {
     const response1 = createContent({ test: 1 });
     const response2 = createContent({ test: false });
     representor.upsert(
-      createHarEntry({ url: `${href}/a/1`, response: response1 }),
+      createHarEntry({ url: `${href}/a/1`, response: response1 })
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/3`, response: response2 }),
+      createHarEntry({ url: `${href}/a/3`, response: response2 })
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/2`, response: response2 }),
+      createHarEntry({ url: `${href}/a/2`, response: response2 })
     );
-    const node: IrNode = representor.rest.data[host]!;
+    const node: IrNode =
+      representor.rest.data[host]!;
 
-    expect(
-      node.childrenStatic["a"]!.childrenDynamic[0]!.data?.methods["post"]!
-        .response["200"]!["application/json"]!.body?.properties,
-    ).toEqual({
+    expect(node.childrenStatic["a"]!.childrenDynamic[0]!
+      .data?.methods["post"]!.response["200"]!["application/json"]!.body?.properties).toEqual({
       test: {
         type: "boolean",
-      },
-    });
+      }
+    })
     expect(node.childrenDynamic).toHaveLength(0);
     expect(Object.values(node.childrenStatic)).toHaveLength(1);
     const a = node.childrenStatic["a"]!;
@@ -247,23 +246,22 @@ describe("upsert and automatic parameterisation integration tests", () => {
     const representor = new Representor();
     const response1 = createContent({ test: 1 });
     representor.upsert(
-      createHarEntry({ url: `${href}/a/1`, response: response1 }),
+      createHarEntry({ url: `${href}/a/1`, response: response1 })
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/2`, response: response1 }),
+      createHarEntry({ url: `${href}/a/2`, response: response1 })
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/3`, response: response1 }),
+      createHarEntry({ url: `${href}/a/3`, response: response1 })
     );
-    const node: IrNode = representor.rest.data[host]!;
-    expect(
-      node.childrenStatic["a"]!.childrenDynamic[0]!.data?.methods["post"]!
-        .response["200"]!["application/json"]!.body?.properties,
-    ).toEqual({
+    const node: IrNode =
+      representor.rest.data[host]!;
+    expect(node.childrenStatic["a"]!.childrenDynamic[0]!
+      .data?.methods["post"]!.response["200"]!["application/json"]!.body?.properties).toEqual({
       test: {
         type: "integer",
-      },
-    });
+      }
+    })
     expect(node.childrenDynamic).toHaveLength(0);
     expect(Object.values(node.childrenStatic)).toHaveLength(1);
     const a = node.childrenStatic["a"]!;
@@ -298,15 +296,16 @@ describe("upsert and automatic parameterisation integration tests", () => {
     const representor = new Representor();
     const response1 = createContent({ test: 1 });
     representor.upsert(
-      createHarEntry({ url: `${href}/a/1/a/1`, response: response1 }),
+      createHarEntry({ url: `${href}/a/1/a/1`, response: response1 })
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/2/a/2`, response: response1 }),
+      createHarEntry({ url: `${href}/a/2/a/2`, response: response1 })
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/3/a/3`, response: response1 }),
+      createHarEntry({ url: `${href}/a/3/a/3`, response: response1 })
     );
-    const node: IrNode = representor.rest.data[host]!;
+    const node: IrNode =
+      representor.rest.data[host]!;
     expect(node.childrenDynamic).toHaveLength(0);
     expect(Object.values(node.childrenStatic)).toHaveLength(1);
     const a1 = node.childrenStatic["a"]!;
@@ -319,14 +318,11 @@ describe("upsert and automatic parameterisation integration tests", () => {
     expect(a2.childrenDynamic).toHaveLength(1);
     expect(Object.values(a2.childrenStatic)).toHaveLength(0);
     const dynamic2 = a2.childrenDynamic[0]!;
-    expect(
-      dynamic2.data?.methods["post"]!.response["200"]!["application/json"]!.body
-        ?.properties,
-    ).toEqual({
+    expect(dynamic2.data?.methods["post"]!.response["200"]!["application/json"]!.body?.properties).toEqual({
       test: {
         type: "integer",
-      },
-    });
+      }
+    })
     expect(dynamic2.childrenDynamic).toHaveLength(0);
     expect(Object.values(dynamic2.childrenStatic)).toHaveLength(0);
   });
@@ -334,39 +330,28 @@ describe("upsert and automatic parameterisation integration tests", () => {
   it("should obey part-in-common heuristic, that equivalence requires at least one similar part", () => {
     const representor = new Representor();
     const response = createContent({ test: 1 });
-    representor.upsert(createHarEntry({ url: `${href}/1/2`, response }));
-    representor.upsert(createHarEntry({ url: `${href}/3/4`, response }));
-    const node: IrNode = representor.rest.data[host]!;
+    representor.upsert(
+      createHarEntry({ url: `${href}/1/2`, response })
+    );
+    representor.upsert(
+      createHarEntry({ url: `${href}/3/4`, response })
+    );
+    const node: IrNode =
+      representor.rest.data[host]!;
     // node
     expect(node.childrenDynamic).toHaveLength(0);
     expect(Object.values(node.childrenStatic)).toHaveLength(2);
     // /1
     expect(node.childrenStatic["1"]?.childrenDynamic).toHaveLength(0);
-    expect(
-      Object.values(node.childrenStatic["1"]!.childrenStatic),
-    ).toHaveLength(1);
+    expect(Object.values(node.childrenStatic["1"]!.childrenStatic)).toHaveLength(1);
     // /3
     expect(node.childrenStatic["3"]?.childrenDynamic).toHaveLength(0);
-    expect(
-      Object.values(node.childrenStatic["3"]!.childrenStatic),
-    ).toHaveLength(1);
+    expect(Object.values(node.childrenStatic["3"]!.childrenStatic)).toHaveLength(1);
     // /1/2
-    expect(
-      Object.values(
-        node.childrenStatic["1"]!.childrenStatic["2"]!.childrenStatic,
-      ),
-    ).toHaveLength(0);
-    expect(
-      node.childrenStatic["1"]?.childrenStatic["2"]?.childrenDynamic,
-    ).toHaveLength(0);
+    expect(Object.values(node.childrenStatic["1"]!.childrenStatic["2"]!.childrenStatic)).toHaveLength(0);
+    expect(node.childrenStatic["1"]?.childrenStatic["2"]?.childrenDynamic).toHaveLength(0);
     // /3/4
-    expect(
-      Object.values(
-        node.childrenStatic["3"]!.childrenStatic["4"]!.childrenStatic,
-      ),
-    ).toHaveLength(0);
-    expect(
-      node.childrenStatic["3"]?.childrenStatic["4"]?.childrenDynamic,
-    ).toHaveLength(0);
+    expect(Object.values(node.childrenStatic["3"]!.childrenStatic["4"]!.childrenStatic)).toHaveLength(0);
+    expect(node.childrenStatic["3"]?.childrenStatic["4"]?.childrenDynamic).toHaveLength(0);
   });
 });

--- a/packages/algorithm/src/representor-rest.test.ts
+++ b/packages/algorithm/src/representor-rest.test.ts
@@ -71,7 +71,7 @@ describe("generation following upsert of REST HAR entries", () => {
     expect(result.getSpec().info.title).toBe("OpenAPI Specification");
     expect(result.getSpec().info.version).toBe("1.0.0");
     expect(result.getSpec().info.description).toBe(
-      "A specification for www.example.com"
+      "A specification for www.example.com",
     );
     expect(result.getSpec().paths).toBeDefined();
   });
@@ -103,7 +103,7 @@ describe("generation following upsert of REST HAR entries", () => {
 
     const mediaTypeObject =
       result.getSpec().paths?.[pathname]?.post?.responses?.["200"]?.content[
-      "application/json"
+        "application/json"
       ];
     expect(mediaTypeObject).toEqual(expectMergeAbc);
     expect(await validateSpec(result)).toEqual({ valid: true });
@@ -126,7 +126,7 @@ describe("generation following upsert of REST HAR entries", () => {
   });
 });
 
-describe('edge cases', () => {
+describe("edge cases", () => {
   it("handles cases where the har method is uppercase and lowercase", async () => {
     const representor = new Representor();
     const entry1 = createHarEntry(createResponse(simpleJsonA));
@@ -140,7 +140,7 @@ describe('edge cases', () => {
 
     const mediaTypeObject =
       result.getSpec().paths?.[pathname]?.post?.responses?.["200"]?.content[
-      "application/json"
+        "application/json"
       ];
     expect(mediaTypeObject).toEqual(expectMergeAbc);
     expect(await validateSpec(result)).toEqual({ valid: true });
@@ -201,28 +201,69 @@ describe("upsert and automatic parameterisation integration tests", () => {
   const host = "api.example.com";
   const href = `https://${host}`;
 
-  it("given /a/b and /a/c have different responses, and adding /a/d with the same type, all endpoints collapse into the dynamic node", () => {
+  it("does not merge an existing non-equivalent route when folding equivalent IDs", () => {
     const representor = new Representor();
     const response1 = createContent({ test: 1 });
     const response2 = createContent({ test: false });
     representor.upsert(
-      createHarEntry({ url: `${href}/a/b`, response: response1 })
+      createHarEntry({ url: `${href}/a/1`, response: response1 }),
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/d`, response: response2 })
+      createHarEntry({ url: `${href}/a/3`, response: response2 }),
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/c`, response: response2 })
+      createHarEntry({ url: `${href}/a/2`, response: response2 }),
     );
-    const node: IrNode =
-      representor.rest.data[host]!;
+    const node: IrNode = representor.rest.data[host]!;
 
-    expect(node.childrenStatic["a"]!.childrenDynamic[0]!
-      .data?.methods["post"]!.response["200"]!["application/json"]!.body?.properties).toEqual({
-        test: {
-          type: ["boolean", "integer"],
-        }
-      })
+    expect(
+      node.childrenStatic["a"]!.childrenDynamic[0]!.data?.methods["post"]!
+        .response["200"]!["application/json"]!.body?.properties,
+    ).toEqual({
+      test: {
+        type: "boolean",
+      },
+    });
+    expect(node.childrenDynamic).toHaveLength(0);
+    expect(Object.values(node.childrenStatic)).toHaveLength(1);
+    const a = node.childrenStatic["a"]!;
+    expect(a.childrenDynamic).toHaveLength(1);
+    expect(Object.values(a.childrenStatic)).toHaveLength(1);
+    expect(
+      a.childrenStatic["1"]!.data?.methods["post"]!.response["200"]![
+        "application/json"
+      ]!.body?.properties,
+    ).toEqual({
+      test: {
+        type: "integer",
+      },
+    });
+    const dynamic = a.childrenDynamic[0]!;
+    expect(dynamic.childrenDynamic).toHaveLength(0);
+    expect(Object.values(dynamic.childrenStatic)).toHaveLength(0);
+  });
+
+  it("given /a/{}, compatible requests match against it", () => {
+    const representor = new Representor();
+    const response1 = createContent({ test: 1 });
+    representor.upsert(
+      createHarEntry({ url: `${href}/a/1`, response: response1 }),
+    );
+    representor.upsert(
+      createHarEntry({ url: `${href}/a/2`, response: response1 }),
+    );
+    representor.upsert(
+      createHarEntry({ url: `${href}/a/3`, response: response1 }),
+    );
+    const node: IrNode = representor.rest.data[host]!;
+    expect(
+      node.childrenStatic["a"]!.childrenDynamic[0]!.data?.methods["post"]!
+        .response["200"]!["application/json"]!.body?.properties,
+    ).toEqual({
+      test: {
+        type: "integer",
+      },
+    });
     expect(node.childrenDynamic).toHaveLength(0);
     expect(Object.values(node.childrenStatic)).toHaveLength(1);
     const a = node.childrenStatic["a"]!;
@@ -233,52 +274,39 @@ describe("upsert and automatic parameterisation integration tests", () => {
     expect(Object.values(dynamic.childrenStatic)).toHaveLength(0);
   });
 
-  it("given /a/{}, requests match against it", () => {
+  it("given /a/{}, incompatible requests do not match against it", () => {
     const representor = new Representor();
-    const response1 = createContent({ test: 1 });
-    const response2 = createContent({ test: false });
+    const response1 = createContent({ test: { value: 1 }, ok: true });
+    const response2 = createContent({ test: [1], ok: true });
     representor.upsert(
-      createHarEntry({ url: `${href}/a/b`, response: response1 })
+      createHarEntry({ url: `${href}/a/1`, response: response1 }),
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/c`, response: response1 })
+      createHarEntry({ url: `${href}/a/2`, response: response1 }),
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/d`, response: response2 })
+      createHarEntry({ url: `${href}/a/3`, response: response2 }),
     );
-    const node: IrNode =
-      representor.rest.data[host]!;
-    expect(node.childrenStatic["a"]!.childrenDynamic[0]!
-      .data?.methods["post"]!.response["200"]!["application/json"]!.body?.properties).toEqual({
-        test: {
-          type: ["boolean", "integer"],
-        }
-      })
-    expect(node.childrenDynamic).toHaveLength(0);
-    expect(Object.values(node.childrenStatic)).toHaveLength(1);
-    const a = node.childrenStatic["a"]!;
+
+    const a = representor.rest.data[host]!.childrenStatic["a"]!;
     expect(a.childrenDynamic).toHaveLength(1);
-    expect(Object.values(a.childrenStatic)).toHaveLength(0);
-    const dynamic = a.childrenDynamic[0]!;
-    expect(dynamic.childrenDynamic).toHaveLength(0);
-    expect(Object.values(dynamic.childrenStatic)).toHaveLength(0);
+    expect(Object.values(a.childrenStatic)).toHaveLength(1);
+    expect(a.childrenStatic["3"]!.data).not.toBeNull();
   });
 
-  it("given /a/{}/a/{}, requests match against it", () => {
+  it("given /a/{}/a/{}, compatible requests match against it", () => {
     const representor = new Representor();
     const response1 = createContent({ test: 1 });
-    const response2 = createContent({ test: false });
     representor.upsert(
-      createHarEntry({ url: `${href}/a/b/a/1`, response: response1 })
+      createHarEntry({ url: `${href}/a/1/a/1`, response: response1 }),
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/c/a/2`, response: response1 })
+      createHarEntry({ url: `${href}/a/2/a/2`, response: response1 }),
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/d/a/3`, response: response2 })
+      createHarEntry({ url: `${href}/a/3/a/3`, response: response1 }),
     );
-    const node: IrNode =
-      representor.rest.data[host]!;
+    const node: IrNode = representor.rest.data[host]!;
     expect(node.childrenDynamic).toHaveLength(0);
     expect(Object.values(node.childrenStatic)).toHaveLength(1);
     const a1 = node.childrenStatic["a"]!;
@@ -291,11 +319,14 @@ describe("upsert and automatic parameterisation integration tests", () => {
     expect(a2.childrenDynamic).toHaveLength(1);
     expect(Object.values(a2.childrenStatic)).toHaveLength(0);
     const dynamic2 = a2.childrenDynamic[0]!;
-    expect(dynamic2.data?.methods["post"]!.response["200"]!["application/json"]!.body?.properties).toEqual({
+    expect(
+      dynamic2.data?.methods["post"]!.response["200"]!["application/json"]!.body
+        ?.properties,
+    ).toEqual({
       test: {
-        type: ["boolean", "integer"],
-      }
-    })
+        type: "integer",
+      },
+    });
     expect(dynamic2.childrenDynamic).toHaveLength(0);
     expect(Object.values(dynamic2.childrenStatic)).toHaveLength(0);
   });
@@ -303,28 +334,39 @@ describe("upsert and automatic parameterisation integration tests", () => {
   it("should obey part-in-common heuristic, that equivalence requires at least one similar part", () => {
     const representor = new Representor();
     const response = createContent({ test: 1 });
-    representor.upsert(
-      createHarEntry({ url: `${href}/1/2`, response })
-    );
-    representor.upsert(
-      createHarEntry({ url: `${href}/3/4`, response })
-    );
-    const node: IrNode =
-      representor.rest.data[host]!;
+    representor.upsert(createHarEntry({ url: `${href}/1/2`, response }));
+    representor.upsert(createHarEntry({ url: `${href}/3/4`, response }));
+    const node: IrNode = representor.rest.data[host]!;
     // node
     expect(node.childrenDynamic).toHaveLength(0);
     expect(Object.values(node.childrenStatic)).toHaveLength(2);
     // /1
     expect(node.childrenStatic["1"]?.childrenDynamic).toHaveLength(0);
-    expect(Object.values(node.childrenStatic["1"]?.childrenStatic!)).toHaveLength(1);
+    expect(
+      Object.values(node.childrenStatic["1"]!.childrenStatic),
+    ).toHaveLength(1);
     // /3
     expect(node.childrenStatic["3"]?.childrenDynamic).toHaveLength(0);
-    expect(Object.values(node.childrenStatic["3"]?.childrenStatic!)).toHaveLength(1);
+    expect(
+      Object.values(node.childrenStatic["3"]!.childrenStatic),
+    ).toHaveLength(1);
     // /1/2
-    expect(Object.values(node.childrenStatic["1"]?.childrenStatic["2"]?.childrenStatic!)).toHaveLength(0);
-    expect(node.childrenStatic["1"]?.childrenStatic["2"]?.childrenDynamic).toHaveLength(0);
+    expect(
+      Object.values(
+        node.childrenStatic["1"]!.childrenStatic["2"]!.childrenStatic,
+      ),
+    ).toHaveLength(0);
+    expect(
+      node.childrenStatic["1"]?.childrenStatic["2"]?.childrenDynamic,
+    ).toHaveLength(0);
     // /3/4
-    expect(Object.values(node.childrenStatic["3"]?.childrenStatic["4"]?.childrenStatic!)).toHaveLength(0);
-    expect(node.childrenStatic["3"]?.childrenStatic["4"]?.childrenDynamic).toHaveLength(0);
+    expect(
+      Object.values(
+        node.childrenStatic["3"]!.childrenStatic["4"]!.childrenStatic,
+      ),
+    ).toHaveLength(0);
+    expect(
+      node.childrenStatic["3"]?.childrenStatic["4"]?.childrenDynamic,
+    ).toHaveLength(0);
   });
 });

--- a/packages/algorithm/src/representor.ts
+++ b/packages/algorithm/src/representor.ts
@@ -3,14 +3,19 @@ import { HarEntry } from "./types/index.js";
 import { harToHarType } from "./har-to-hartype/index.js";
 import stringify from "json-stable-stringify";
 import { formatHar } from "./utils/index.js";
+import { PathParameterisationOptions } from "./parameterisation/parameterisation-options.js";
+
+type RepresentorOptions = {
+  parameterisation?: Partial<PathParameterisationOptions>;
+};
 
 /**
  * Delegate HAR entries to different representations
  */
 export class Representor {
   rest: RestManager;
-  constructor() {
-    this.rest = new RestManager();
+  constructor(options: RepresentorOptions = {}) {
+    this.rest = new RestManager(options.parameterisation);
   }
 
   /**
@@ -30,17 +35,19 @@ export class Representor {
       // console.log("gRPC-Web not supported yet");
     }
     return false;
-  }
+  };
 
   reset = (): void => {
     this.rest.reset();
-  }
+  };
 
   serialise = (): string => {
-    return stringify({
-      rest: this.rest.serialise(),
-    }) || "";
-  }
+    return (
+      stringify({
+        rest: this.rest.serialise(),
+      }) || ""
+    );
+  };
 
   deserialise = (input: string): boolean => {
     try {
@@ -52,5 +59,5 @@ export class Representor {
     } catch {
       return false;
     }
-  }
+  };
 }

--- a/packages/algorithm/src/representor.ts
+++ b/packages/algorithm/src/representor.ts
@@ -35,19 +35,17 @@ export class Representor {
       // console.log("gRPC-Web not supported yet");
     }
     return false;
-  };
+  }
 
   reset = (): void => {
     this.rest.reset();
-  };
+  }
 
   serialise = (): string => {
-    return (
-      stringify({
-        rest: this.rest.serialise(),
-      }) || ""
-    );
-  };
+    return stringify({
+      rest: this.rest.serialise(),
+    }) || "";
+  }
 
   deserialise = (input: string): boolean => {
     try {
@@ -59,5 +57,5 @@ export class Representor {
     } catch {
       return false;
     }
-  };
+  }
 }

--- a/packages/algorithm/src/rest.ts
+++ b/packages/algorithm/src/rest.ts
@@ -6,28 +6,47 @@ import { OpenApiBuilder } from "openapi3-ts/oas31";
 import { pick } from "lodash";
 import { serialiseRest } from "./utils/index.js";
 import { automaticParameterisation } from "./parameterisation/automatic-parameterisation.js";
+import {
+  PathParameterisationOptions,
+  resolvePathParameterisationOptions,
+} from "./parameterisation/parameterisation-options.js";
 
 type Data = HostToNode;
 type Output = OpenApiBuilder;
 
 export class RestManager extends Manager<Data, Output> {
   data: Data;
-  constructor() {
+  parameterisationOptions: PathParameterisationOptions;
+  constructor(options: Partial<PathParameterisationOptions> = {}) {
     super();
     this.data = {};
+    this.parameterisationOptions = resolvePathParameterisationOptions(options);
   }
 
+  setParameterisationOptions = (
+    options: Partial<PathParameterisationOptions>,
+  ): void => {
+    this.parameterisationOptions = resolvePathParameterisationOptions(options);
+  };
+
   upsert = (data: ValidHar): void => {
-    const host = new URL(data.har.request.url).host;
+    const url = new URL(data.har.request.url);
+    const host = url.host;
     const rootNode = this.data[host] || null;
-    const { root, inserted } = updateOrCreate({ data, rootNode });
+    const { root, inserted } = updateOrCreate({
+      data,
+      options: this.parameterisationOptions,
+      rootNode,
+    });
     this.data[host] = root;
     automaticParameterisation({
-      pathname: data.har.request.url.split("/").slice(3),
+      pathname: url.pathname.split("/").filter((part) => part.length > 0),
       insertedNode: inserted,
       rootNode: root,
       method: data.har.request.method,
       mimeType: data.har.response.content.mimeType,
+      statusCode: data.har.response.status.toString(),
+      options: this.parameterisationOptions,
     });
   };
 

--- a/packages/algorithm/src/types/hartype.ts
+++ b/packages/algorithm/src/types/hartype.ts
@@ -1,10 +1,10 @@
 import { HarEntry } from "./index.js";
 
 // Entries that appear to be API requests
-export interface HarRestJson extends HarEntry {}
-export interface HarRestXml extends HarEntry {}
-export interface HarGraphQL extends HarEntry {}
-export interface HarGrpcWeb extends HarEntry {}
+export type HarRestJson = HarEntry;
+export type HarRestXml = HarEntry;
+export type HarGraphQL = HarEntry;
+export type HarGrpcWeb = HarEntry;
 
-export type HarAny = HarRestJson | HarRestXml | HarGraphQL | HarGrpcWeb
-export type HarRestful = HarRestJson | HarRestXml
+export type HarAny = HarRestJson | HarRestXml | HarGraphQL | HarGrpcWeb;
+export type HarRestful = HarRestJson | HarRestXml;

--- a/packages/algorithm/src/types/hartype.ts
+++ b/packages/algorithm/src/types/hartype.ts
@@ -1,10 +1,10 @@
 import { HarEntry } from "./index.js";
 
 // Entries that appear to be API requests
-export type HarRestJson = HarEntry;
-export type HarRestXml = HarEntry;
-export type HarGraphQL = HarEntry;
-export type HarGrpcWeb = HarEntry;
+export type HarRestJson = HarEntry
+export type HarRestXml = HarEntry
+export type HarGraphQL = HarEntry
+export type HarGrpcWeb = HarEntry
 
-export type HarAny = HarRestJson | HarRestXml | HarGraphQL | HarGrpcWeb;
-export type HarRestful = HarRestJson | HarRestXml;
+export type HarAny = HarRestJson | HarRestXml | HarGraphQL | HarGrpcWeb
+export type HarRestful = HarRestJson | HarRestXml

--- a/packages/algorithm/src/update-or-create/merge-node-data.ts
+++ b/packages/algorithm/src/update-or-create/merge-node-data.ts
@@ -6,10 +6,7 @@ type Req = NonNullable<NodeData["methods"]["get"]["request"]>;
 type Res = NodeData["methods"]["get"]["response"];
 type Cookies = NodeData["methods"]["get"]["cookies"];
 
-const mergeCookies = (
-  dest: NonNullable<Cookies>,
-  src: NonNullable<Cookies>,
-) => ({
+const mergeCookies = (dest: NonNullable<Cookies>, src: NonNullable<Cookies>) => ({
   ...dest,
   ...src,
 });
@@ -55,7 +52,8 @@ const mergeResponse = (dest: Data, src: Res = {}) => {
         } else if (srcData.body) {
           selector.body = mergeSchemas([selector.body, srcData.body]);
         }
-        selector.mostRecent = mediaTypeData.mostRecent;
+        selector.mostRecent =
+          mediaTypeData.mostRecent;
       }
     });
   });
@@ -80,7 +78,7 @@ export const mergeNodeData = (dest: NodeData, src: NodeData): NodeData => {
       } else {
         dest.methods[method].cookies = mergeCookies(
           dest.methods[method].cookies,
-          src.methods[method].cookies,
+          src.methods[method].cookies
         );
       }
     }
@@ -92,15 +90,15 @@ export const mergeNodeData = (dest: NodeData, src: NodeData): NodeData => {
     if (destSchema.queryParameters || srcSchema.queryParameters) {
       destSchema.queryParameters = {
         ...destSchema.queryParameters,
-        ...srcSchema.queryParameters,
-      };
+        ...srcSchema.queryParameters
+      }
     }
     // Merge request headers
     if (destSchema.requestHeaders || srcSchema.requestHeaders) {
       const destReqHeaders = destSchema.requestHeaders || [];
       const srcReqHeaders = srcSchema.requestHeaders || [];
       destSchema.requestHeaders = Array.from(
-        new Set([...destReqHeaders, ...srcReqHeaders]),
+        new Set([...destReqHeaders, ...srcReqHeaders])
       );
     }
     // Merge response headers
@@ -108,7 +106,7 @@ export const mergeNodeData = (dest: NodeData, src: NodeData): NodeData => {
       const destResHeaders = destSchema.responseHeaders || [];
       const srcResHeaders = srcSchema.responseHeaders || [];
       destSchema.responseHeaders = Array.from(
-        new Set([...destResHeaders, ...srcResHeaders]),
+        new Set([...destResHeaders, ...srcResHeaders])
       );
     }
     // Merge responses

--- a/packages/algorithm/src/update-or-create/merge-node-data.ts
+++ b/packages/algorithm/src/update-or-create/merge-node-data.ts
@@ -1,4 +1,4 @@
-import { mergeSchemas, Schema } from "genson-js";
+import { mergeSchemas } from "genson-js";
 import { NodeData } from "../types/index.js";
 
 type Data = NodeData["methods"]["get"];
@@ -6,7 +6,10 @@ type Req = NonNullable<NodeData["methods"]["get"]["request"]>;
 type Res = NodeData["methods"]["get"]["response"];
 type Cookies = NodeData["methods"]["get"]["cookies"];
 
-const mergeCookies = (dest: NonNullable<Cookies>, src: NonNullable<Cookies>) => ({
+const mergeCookies = (
+  dest: NonNullable<Cookies>,
+  src: NonNullable<Cookies>,
+) => ({
   ...dest,
   ...src,
 });
@@ -52,8 +55,7 @@ const mergeResponse = (dest: Data, src: Res = {}) => {
         } else if (srcData.body) {
           selector.body = mergeSchemas([selector.body, srcData.body]);
         }
-        selector.mostRecent =
-          mediaTypeData.mostRecent;
+        selector.mostRecent = mediaTypeData.mostRecent;
       }
     });
   });
@@ -78,7 +80,7 @@ export const mergeNodeData = (dest: NodeData, src: NodeData): NodeData => {
       } else {
         dest.methods[method].cookies = mergeCookies(
           dest.methods[method].cookies,
-          src.methods[method].cookies
+          src.methods[method].cookies,
         );
       }
     }
@@ -90,15 +92,15 @@ export const mergeNodeData = (dest: NodeData, src: NodeData): NodeData => {
     if (destSchema.queryParameters || srcSchema.queryParameters) {
       destSchema.queryParameters = {
         ...destSchema.queryParameters,
-        ...srcSchema.queryParameters
-      }
+        ...srcSchema.queryParameters,
+      };
     }
     // Merge request headers
     if (destSchema.requestHeaders || srcSchema.requestHeaders) {
       const destReqHeaders = destSchema.requestHeaders || [];
       const srcReqHeaders = srcSchema.requestHeaders || [];
       destSchema.requestHeaders = Array.from(
-        new Set([...destReqHeaders, ...srcReqHeaders])
+        new Set([...destReqHeaders, ...srcReqHeaders]),
       );
     }
     // Merge response headers
@@ -106,7 +108,7 @@ export const mergeNodeData = (dest: NodeData, src: NodeData): NodeData => {
       const destResHeaders = destSchema.responseHeaders || [];
       const srcResHeaders = srcSchema.responseHeaders || [];
       destSchema.responseHeaders = Array.from(
-        new Set([...destResHeaders, ...srcResHeaders])
+        new Set([...destResHeaders, ...srcResHeaders]),
       );
     }
     // Merge responses

--- a/packages/algorithm/src/update-or-create/update-or-create.ts
+++ b/packages/algorithm/src/update-or-create/update-or-create.ts
@@ -1,24 +1,37 @@
-import { IrNode } from '../types/index.js';
-import { pathToParts } from './path-to-parts.js';
-import { createNodeData } from './create-node-data.js';
-import { createNode } from '../utils/index.js';
-import { ValidHar } from '../har-to-hartype/index.js';
-import { mergeNodeData } from './merge-node-data.js';
-import { getStaticChildMatch } from '../utils/index.js';
-import { matchDynamicChildren } from '../utils/dynamic-children-helpers.js';
+import { IrNode } from "../types/index.js";
+import { pathToParts } from "./path-to-parts.js";
+import { createNodeData } from "./create-node-data.js";
+import { createNode } from "../utils/index.js";
+import { ValidHar } from "../har-to-hartype/index.js";
+import { mergeNodeData } from "./merge-node-data.js";
+import { getStaticChildMatch } from "../utils/index.js";
+import { matchDynamicChildren } from "../utils/dynamic-children-helpers.js";
+import { NodeData } from "../types/ir-graph-node-data.js";
+import { isNodeDataEquivalent } from "../parameterisation/node-data-equivalence.js";
+import { isStrongPathParameterValue } from "../parameterisation/path-parameter-values.js";
+import {
+  PathParameterisationOptions,
+  resolvePathParameterisationOptions,
+} from "../parameterisation/parameterisation-options.js";
 
 type UpdateOrCreateNodeParams = {
+  options: PathParameterisationOptions;
   node: IrNode;
   parts: string[];
-  data: ValidHar;
-}
+  data: NodeData;
+};
 
-function updateOrCreateNode({ node, parts, data }: UpdateOrCreateNodeParams): IrNode {
+function updateOrCreateNode({
+  options,
+  node,
+  parts,
+  data,
+}: UpdateOrCreateNodeParams): IrNode {
   // Base case, no more parts to match. Update or create the node
   // If node.data is null, then it becomes the harEntry (create)
   // Otherwise, merge the harEntry into the existing data (update)
   if (parts.length === 0) {
-    const src = createNodeData({ data });
+    const src = data;
     const dest = node.data;
     if (!dest) node.data = src;
     else node.data = mergeNodeData(dest, src);
@@ -29,36 +42,110 @@ function updateOrCreateNode({ node, parts, data }: UpdateOrCreateNodeParams): Ir
   // Look at dynamic nodes first
   // This is important because we want to match against this first, should it exist
   // Prior to going down that path, confirm that an endpoint exists in the subgraph
-  if (dynamicMatch && nodeHasDataForPath(dynamicMatch, parts.slice(1))) {
-    return updateOrCreateNode({ node: dynamicMatch, parts: parts.slice(1), data });
+  if (
+    dynamicMatch &&
+    canDynamicMatchPart(part, dynamicMatch) &&
+    nodeHasDataForPath(dynamicMatch, parts.slice(1), data, options)
+  ) {
+    return updateOrCreateNode({
+      options,
+      node: dynamicMatch,
+      parts: parts.slice(1),
+      data,
+    });
   }
   // Look for an existing match, if found, continue the search
   const staticMatch = getStaticChildMatch(part, node);
   if (staticMatch) {
-    return updateOrCreateNode({ node: staticMatch, parts: parts.slice(1), data });
+    return updateOrCreateNode({
+      options,
+      node: staticMatch,
+      parts: parts.slice(1),
+      data,
+    });
   }
   // Create a node if no match is found
   // If we get to this point, parts is non-empty and there is neither a static or dynamic match
   node.childrenStatic ??= {};
   node.childrenStatic[part] = createNode({ key: part, parent: node });
-  return updateOrCreateNode({ node: node.childrenStatic[part], parts: parts.slice(1), data });
+  return updateOrCreateNode({
+    options,
+    node: node.childrenStatic[part],
+    parts: parts.slice(1),
+    data,
+  });
 }
 
-const nodeHasDataForPath = (node: IrNode, parts: string[]): boolean => {
+const getPathPartIndex = (node: IrNode): number => {
+  if (!node.parent) return -1;
+  return getPathPartIndex(node.parent) + 1;
+};
+
+const collectMostRecentPathPartsAtIndex = (
+  node: IrNode,
+  index: number,
+): string[] => {
+  const result: string[] = [];
+  const current = node.data?.mostRecentPathname.split("/").slice(1)[index];
+  if (current) {
+    result.push(current);
+  }
+  for (const child of Object.values(node.childrenStatic)) {
+    result.push(...collectMostRecentPathPartsAtIndex(child, index));
+  }
+  for (const child of node.childrenDynamic) {
+    result.push(...collectMostRecentPathPartsAtIndex(child, index));
+  }
+  return result;
+};
+
+const canDynamicMatchPart = (part: string, dynamicNode: IrNode): boolean => {
+  const examples = collectMostRecentPathPartsAtIndex(
+    dynamicNode,
+    getPathPartIndex(dynamicNode),
+  );
+  if (!examples.length) return true;
+  if (examples.every(isStrongPathParameterValue)) {
+    return isStrongPathParameterValue(part);
+  }
+  return true;
+};
+
+const nodeHasDataForPath = (
+  node: IrNode,
+  parts: string[],
+  data: NodeData,
+  options: PathParameterisationOptions,
+): boolean => {
   if (parts.length === 0) {
-    if (node.data) {
-      return true;
-    }
-    return false;
+    return Boolean(
+      node.data &&
+        // Existing dynamic routes can accept later compatible-shape examples,
+        // but only after the dynamic route was already established.
+        isNodeDataEquivalent(node.data, data, {
+          compatibleShape: options.enabled && options.compatibleShape,
+          mode: "established",
+        }),
+    );
   }
   const part = parts[0]!;
   if (node.childrenStatic && node.childrenStatic[part]) {
-    if (nodeHasDataForPath(node.childrenStatic[part], parts.slice(1))) {
+    if (
+      nodeHasDataForPath(
+        node.childrenStatic[part],
+        parts.slice(1),
+        data,
+        options,
+      )
+    ) {
       return true;
     }
   }
   for (const dynamicNode of node.childrenDynamic) {
-    if (nodeHasDataForPath(dynamicNode, parts.slice(1))) {
+    if (
+      canDynamicMatchPart(part, dynamicNode) &&
+      nodeHasDataForPath(dynamicNode, parts.slice(1), data, options)
+    ) {
       return true;
     }
   }
@@ -67,18 +154,28 @@ const nodeHasDataForPath = (node: IrNode, parts: string[]): boolean => {
 
 type UpdateOrCreateParams = {
   data: ValidHar;
+  options?: Partial<PathParameterisationOptions>;
   rootNode: IrNode | null;
-}
-export function updateOrCreate({ data, rootNode }: UpdateOrCreateParams): { root: IrNode, inserted: IrNode } {
+};
+export function updateOrCreate({
+  data,
+  options: inputOptions,
+  rootNode,
+}: UpdateOrCreateParams): {
+  root: IrNode;
+  inserted: IrNode;
+} {
   const { har } = data;
   if (!rootNode) {
     const host = new URL(har.request.url).host;
     rootNode = createNode({ key: host });
   }
+  const options = resolvePathParameterisationOptions(inputOptions);
   const newNode = updateOrCreateNode({
+    options,
     node: rootNode,
     parts: pathToParts(har),
-    data,
+    data: createNodeData({ data }),
   });
   return { root: rootNode, inserted: newNode };
 }

--- a/packages/algorithm/src/update-or-create/update-or-create.ts
+++ b/packages/algorithm/src/update-or-create/update-or-create.ts
@@ -1,32 +1,27 @@
-import { IrNode } from "../types/index.js";
-import { pathToParts } from "./path-to-parts.js";
-import { createNodeData } from "./create-node-data.js";
-import { createNode } from "../utils/index.js";
-import { ValidHar } from "../har-to-hartype/index.js";
-import { mergeNodeData } from "./merge-node-data.js";
-import { getStaticChildMatch } from "../utils/index.js";
-import { matchDynamicChildren } from "../utils/dynamic-children-helpers.js";
-import { NodeData } from "../types/ir-graph-node-data.js";
-import { isNodeDataEquivalent } from "../parameterisation/node-data-equivalence.js";
-import { isStrongPathParameterValue } from "../parameterisation/path-parameter-values.js";
+import { IrNode } from '../types/index.js';
+import { pathToParts } from './path-to-parts.js';
+import { createNodeData } from './create-node-data.js';
+import { createNode } from '../utils/index.js';
+import { ValidHar } from '../har-to-hartype/index.js';
+import { mergeNodeData } from './merge-node-data.js';
+import { getStaticChildMatch } from '../utils/index.js';
+import { matchDynamicChildren } from '../utils/dynamic-children-helpers.js';
+import { NodeData } from '../types/ir-graph-node-data.js';
+import { isNodeDataEquivalent } from '../parameterisation/node-data-equivalence.js';
+import { isStrongPathParameterValue } from '../parameterisation/path-parameter-values.js';
 import {
   PathParameterisationOptions,
   resolvePathParameterisationOptions,
-} from "../parameterisation/parameterisation-options.js";
+} from '../parameterisation/parameterisation-options.js';
 
 type UpdateOrCreateNodeParams = {
   options: PathParameterisationOptions;
   node: IrNode;
   parts: string[];
   data: NodeData;
-};
+}
 
-function updateOrCreateNode({
-  options,
-  node,
-  parts,
-  data,
-}: UpdateOrCreateNodeParams): IrNode {
+function updateOrCreateNode({ options, node, parts, data }: UpdateOrCreateNodeParams): IrNode {
   // Base case, no more parts to match. Update or create the node
   // If node.data is null, then it becomes the harEntry (create)
   // Otherwise, merge the harEntry into the existing data (update)
@@ -47,33 +42,18 @@ function updateOrCreateNode({
     canDynamicMatchPart(part, dynamicMatch) &&
     nodeHasDataForPath(dynamicMatch, parts.slice(1), data, options)
   ) {
-    return updateOrCreateNode({
-      options,
-      node: dynamicMatch,
-      parts: parts.slice(1),
-      data,
-    });
+    return updateOrCreateNode({ options, node: dynamicMatch, parts: parts.slice(1), data });
   }
   // Look for an existing match, if found, continue the search
   const staticMatch = getStaticChildMatch(part, node);
   if (staticMatch) {
-    return updateOrCreateNode({
-      options,
-      node: staticMatch,
-      parts: parts.slice(1),
-      data,
-    });
+    return updateOrCreateNode({ options, node: staticMatch, parts: parts.slice(1), data });
   }
   // Create a node if no match is found
   // If we get to this point, parts is non-empty and there is neither a static or dynamic match
   node.childrenStatic ??= {};
   node.childrenStatic[part] = createNode({ key: part, parent: node });
-  return updateOrCreateNode({
-    options,
-    node: node.childrenStatic[part],
-    parts: parts.slice(1),
-    data,
-  });
+  return updateOrCreateNode({ options, node: node.childrenStatic[part], parts: parts.slice(1), data });
 }
 
 const getPathPartIndex = (node: IrNode): number => {
@@ -130,14 +110,7 @@ const nodeHasDataForPath = (
   }
   const part = parts[0]!;
   if (node.childrenStatic && node.childrenStatic[part]) {
-    if (
-      nodeHasDataForPath(
-        node.childrenStatic[part],
-        parts.slice(1),
-        data,
-        options,
-      )
-    ) {
+    if (nodeHasDataForPath(node.childrenStatic[part], parts.slice(1), data, options)) {
       return true;
     }
   }
@@ -161,10 +134,7 @@ export function updateOrCreate({
   data,
   options: inputOptions,
   rootNode,
-}: UpdateOrCreateParams): {
-  root: IrNode;
-  inserted: IrNode;
-} {
+}: UpdateOrCreateParams): { root: IrNode, inserted: IrNode } {
   const { har } = data;
   if (!rootNode) {
     const host = new URL(har.request.url).host;

--- a/packages/algorithm/src/utils/serialisation.ts
+++ b/packages/algorithm/src/utils/serialisation.ts
@@ -6,8 +6,7 @@ export const serialiseRest = (data: HostToNode): string | null => {
   const cloned = cloneDeep(data);
   const stripParentProperty = (node: IrNode) => {
     if (node.parent) {
-      // @ts-expect-error
-      delete node.parent;
+      delete (node as Partial<IrNode>).parent;
     }
     node.childrenDynamic.forEach(stripParentProperty);
     Object.values(node.childrenStatic).forEach(stripParentProperty);

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -3,6 +3,7 @@ import eslintConfigPrettier from "eslint-config-prettier";
 import turboPlugin from "eslint-plugin-turbo";
 import tseslint from "typescript-eslint";
 import onlyWarn from "eslint-plugin-only-warn";
+import globals from "globals";
 
 /**
  * A shared ESLint configuration for the repository.
@@ -27,6 +28,15 @@ export const config = [
     },
   },
   {
-    ignores: ["dist/**"],
+    files: ["**/*.config.js", "**/*.config.cjs"],
+    languageOptions: {
+      globals: globals.node,
+    },
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+  },
+  {
+    ignores: ["**/dist/**", "**/.output/**"],
   },
 ];

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -1,3 +1,3 @@
-export * from "./select-file";
-export * from "./load-save";
-export * from "./write-text-to-file";
+export * from "./select-file.js";
+export * from "./load-save.js";
+export * from "./write-text-to-file.js";

--- a/packages/helpers/src/select-file.ts
+++ b/packages/helpers/src/select-file.ts
@@ -1,6 +1,9 @@
 import type { Har, Entry } from "har-format";
 
-export const selectFile = (onFinish: (entries: Entry[]) => void, toast: (arg: Object) => void = () => { }) => {
+export const selectFile = (
+  onFinish: (entries: Entry[]) => void,
+  toast: (arg: object) => void = () => {},
+) => {
   return async () => {
     const input = document.createElement("input");
     input.type = "file";

--- a/packages/helpers/src/select-file.ts
+++ b/packages/helpers/src/select-file.ts
@@ -1,9 +1,6 @@
 import type { Har, Entry } from "har-format";
 
-export const selectFile = (
-  onFinish: (entries: Entry[]) => void,
-  toast: (arg: object) => void = () => {},
-) => {
+export const selectFile = (onFinish: (entries: Entry[]) => void, toast: (arg: object) => void = () => { }) => {
   return async () => {
     const input = document.createElement("input");
     input.type = "file";

--- a/packages/helpers/tsconfig.json
+++ b/packages/helpers/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@demystify/typescript-config/base.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,7 +7,7 @@
   "main": "./src/index.ts",
   "scripts": {
     "lint": "eslint . --max-warnings 0",
-    "check-types": "tsc --noEmit",
+    "check-types": "vue-tsc --noEmit",
     "shadcn": "npx shadcn-vue@latest"
   },
   "dependencies": {

--- a/packages/ui/src/components/App.vue
+++ b/packages/ui/src/components/App.vue
@@ -207,11 +207,7 @@ const boundOnClickLoad = async () => {
   } catch (e: any) {
     console.log(e.message);
     // The error below happens every time the user closes the file dialog without a selection
-    if (
-      e.message.startsWith(
-        "Error calling method: open : no such file or directory",
-      )
-    ) {
+    if (e.message.startsWith("Error calling method: open : no such file or directory")) {
       return;
     }
     toast({

--- a/packages/ui/src/components/App.vue
+++ b/packages/ui/src/components/App.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { ref, defineProps, watch } from "vue";
-import type { HarEntry } from "demystify-lib";
-import { Representor } from "demystify-lib";
+import type { HarEntry, PathParameterisationOptions } from "demystify-lib";
+import { defaultPathParameterisationOptions, Representor } from "demystify-lib";
 import { debounce } from "lodash";
 import "../index.css";
 import MenuPage from "./MenuPage.vue";
@@ -43,7 +43,13 @@ interface OpenAPIPage extends Page {
   data: OpenApiPageData;
 }
 
-const representor = ref<Representor>(new Representor());
+const parameterisationOptions = ref<PathParameterisationOptions>({
+  ...defaultPathParameterisationOptions,
+});
+const createRepresentor = () =>
+  new Representor({ parameterisation: parameterisationOptions.value });
+const representor = ref<Representor>(createRepresentor());
+const replayableHar = ref<HarEntry[]>([]);
 const currentPage = ref<Page>({
   name: "menu",
   data: { representor: representor.value, items: [] },
@@ -80,13 +86,47 @@ const debouncedUpdate = debounce(() => {
   }
 }, 500);
 
+const upsertEntry = (entry: HarEntry, replayable: boolean): boolean => {
+  const wasUpsert = representor.value.upsert(entry);
+  if (wasUpsert && replayable) {
+    replayableHar.value.push(entry);
+  }
+  return wasUpsert;
+};
+
+const rebuildRepresentor = () => {
+  // UI toggles can rebuild only from HAR entries captured or loaded in this
+  // session. Serialized Demystify saves contain the already-built IR tree.
+  const entries = [...replayableHar.value];
+  representor.value = createRepresentor();
+  for (const entry of entries) {
+    representor.value.upsert(entry);
+  }
+  if (isMenuPage(currentPage.value)) {
+    updateMenuPage();
+  } else if (isOpenAPIPage(currentPage.value)) {
+    updateOpenAPIPage(currentPage.value.data.hostnames);
+  }
+};
+
+const onChangeParameterisationOptions = (
+  options: PathParameterisationOptions,
+) => {
+  parameterisationOptions.value = options;
+  if (replayableHar.value.length) {
+    rebuildRepresentor();
+    return;
+  }
+  representor.value.rest.setParameterisationOptions(options);
+};
+
 watch(
   () => props.har,
   (har) => {
     if (har.length) {
       try {
         for (const entry of har) {
-          const wasUpsert = representor.value.upsert(entry);
+          const wasUpsert = upsertEntry(entry, true);
           if (wasUpsert) {
             debouncedUpdate();
           }
@@ -95,7 +135,7 @@ watch(
         console.error(e);
       }
     }
-  }
+  },
 );
 
 const onClickViewApi = (hostnames: string[]) => {
@@ -107,7 +147,7 @@ const tryToLoadHarText = (text: string) => {
     const har = JSON.parse(text) as Har;
     let count = 0;
     for (const entry of har.log.entries) {
-      const wasUpsert = representor.value.upsert(entry);
+      const wasUpsert = upsertEntry(entry, true);
       if (wasUpsert) {
         count++;
       }
@@ -128,7 +168,8 @@ const tryToLoadHarText = (text: string) => {
 };
 
 const onClickReset = () => {
-  representor.value = new Representor();
+  replayableHar.value = [];
+  representor.value = createRepresentor();
   updateMenuPage();
 };
 
@@ -155,6 +196,7 @@ const boundOnClickLoad = async () => {
     if (!successful) {
       throw new Error("Failed to load save");
     }
+    replayableHar.value = [];
     updateMenuPage();
     toast({
       title: "Load Successful",
@@ -165,7 +207,11 @@ const boundOnClickLoad = async () => {
   } catch (e: any) {
     console.log(e.message);
     // The error below happens every time the user closes the file dialog without a selection
-    if (e.message.startsWith("Error calling method: open : no such file or directory")) {
+    if (
+      e.message.startsWith(
+        "Error calling method: open : no such file or directory",
+      )
+    ) {
       return;
     }
     toast({
@@ -194,6 +240,8 @@ const onClickDeleteHost = (hostname: string) => {
     :onClickReset="onClickReset"
     :onClickHarText="tryToLoadHarText"
     :onClickDeleteHost="onClickDeleteHost"
+    :parameterisationOptions="parameterisationOptions"
+    :onChangeParameterisationOptions="onChangeParameterisationOptions"
   >
     <slot></slot>
   </MenuPage>

--- a/packages/ui/src/components/MenuPage.vue
+++ b/packages/ui/src/components/MenuPage.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { Representor } from "demystify-lib";
+import type { PathParameterisationOptions, Representor } from "demystify-lib";
 import Table from "./Table.vue";
 import {
   Card,
@@ -30,6 +30,10 @@ defineProps<{
   onClickReset: () => void;
   onClickHarText: (text: string) => void;
   onClickDeleteHost: (hostname: string) => void;
+  parameterisationOptions: PathParameterisationOptions;
+  onChangeParameterisationOptions: (
+    options: PathParameterisationOptions,
+  ) => void;
 }>();
 </script>
 
@@ -83,6 +87,8 @@ defineProps<{
           :onClickSelectHar="onClickSelectHar"
           :onClickReset="onClickReset"
           :onClickHarText="onClickHarText"
+          :parameterisationOptions="parameterisationOptions"
+          :onChangeParameterisationOptions="onChangeParameterisationOptions"
         />
       </CardFooter>
     </Card>

--- a/packages/ui/src/components/MenuPageButtonRow.vue
+++ b/packages/ui/src/components/MenuPageButtonRow.vue
@@ -109,8 +109,7 @@ To copy a HAR in the network tab of modern browsers, right click on a request, c
       />
       <div class="flex justify-between">
         <Button variant="secondary" @click="handleCancel">Cancel</Button>
-        <Button @click="handleLoadText" :disabled="!textareaContent"
-          >Save</Button
+        <Button @click="handleLoadText" :disabled="!textareaContent">Save</Button
         >
       </div>
     </DialogContent>

--- a/packages/ui/src/components/MenuPageButtonRow.vue
+++ b/packages/ui/src/components/MenuPageButtonRow.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { ref } from "vue";
+import type { PathParameterisationOptions } from "demystify-lib";
 import { Button } from "./ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
 import { Textarea } from "./ui/textarea";
@@ -8,6 +9,10 @@ const props = defineProps<{
   onClickSelectHar: () => void;
   onClickReset: () => void;
   onClickHarText: (text: string) => void;
+  parameterisationOptions: PathParameterisationOptions;
+  onChangeParameterisationOptions: (
+    options: PathParameterisationOptions,
+  ) => void;
 }>();
 
 const showModal = ref(false);
@@ -29,6 +34,16 @@ const handleCancel = () => {
   showModal.value = false;
   textareaContent.value = "";
 };
+const updateParameterisationOption = (
+  key: keyof PathParameterisationOptions,
+  event: Event,
+) => {
+  const target = event.target as HTMLInputElement;
+  props.onChangeParameterisationOptions({
+    ...props.parameterisationOptions,
+    [key]: target.checked,
+  });
+};
 const textAreaPlaceholder = `{ "log": { "entries": ... } }
 
 To copy a HAR in the network tab of modern browsers, right click on a request, click copy, then copy as HAR.`;
@@ -36,7 +51,43 @@ To copy a HAR in the network tab of modern browsers, right click on a request, c
 
 <template>
   <div class="flex-1 flex gap-4 flex-col">
-    <div class="flex gap-2 w-full"></div>
+    <div class="flex gap-3 w-full flex-wrap text-sm">
+      <label class="flex items-center gap-2">
+        <input
+          type="checkbox"
+          :checked="parameterisationOptions.enabled"
+          @change="updateParameterisationOption('enabled', $event)"
+        />
+        Auto-fold
+      </label>
+      <label class="flex items-center gap-2">
+        <input
+          type="checkbox"
+          :checked="parameterisationOptions.foldStrongIds"
+          :disabled="!parameterisationOptions.enabled"
+          @change="updateParameterisationOption('foldStrongIds', $event)"
+        />
+        IDs
+      </label>
+      <label class="flex items-center gap-2">
+        <input
+          type="checkbox"
+          :checked="parameterisationOptions.foldText"
+          :disabled="!parameterisationOptions.enabled"
+          @change="updateParameterisationOption('foldText', $event)"
+        />
+        Text
+      </label>
+      <label class="flex items-center gap-2">
+        <input
+          type="checkbox"
+          :checked="parameterisationOptions.compatibleShape"
+          :disabled="!parameterisationOptions.enabled"
+          @change="updateParameterisationOption('compatibleShape', $event)"
+        />
+        Shape
+      </label>
+    </div>
     <div class="flex gap-2 w-full">
       <Button @click="onClickSelectHar">Select HAR</Button>
       <Button @click="showModal = true">Paste HAR</Button>
@@ -58,7 +109,8 @@ To copy a HAR in the network tab of modern browsers, right click on a request, c
       />
       <div class="flex justify-between">
         <Button variant="secondary" @click="handleCancel">Cancel</Button>
-        <Button @click="handleLoadText" :disabled="!textareaContent">Save</Button
+        <Button @click="handleLoadText" :disabled="!textareaContent"
+          >Save</Button
         >
       </div>
     </DialogContent>

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,7 +1,7 @@
-import type { Updater } from "@tanstack/vue-table";
-import type { Ref } from "vue";
-import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import type { Updater } from '@tanstack/vue-table'
+import type { Ref } from 'vue'
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -10,7 +10,7 @@ export function cn(...inputs: ClassValue[]) {
 export function valueUpdater<T>(updaterOrValue: Updater<T>, ref: Ref<T>) {
   type UpdaterFn = (old: T) => T;
   ref.value =
-    typeof updaterOrValue === "function"
+    typeof updaterOrValue === 'function'
       ? (updaterOrValue as UpdaterFn)(ref.value)
-      : updaterOrValue;
+      : updaterOrValue
 }

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,15 +1,16 @@
-import type { Updater } from '@tanstack/vue-table'
-import type { Ref } from 'vue'
-import { type ClassValue, clsx } from 'clsx'
-import { twMerge } from 'tailwind-merge'
+import type { Updater } from "@tanstack/vue-table";
+import type { Ref } from "vue";
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }
 
-export function valueUpdater<T extends Updater<any>>(updaterOrValue: T, ref: Ref) {
-  ref.value
-    = typeof updaterOrValue === 'function'
-      ? updaterOrValue(ref.value)
-      : updaterOrValue
+export function valueUpdater<T>(updaterOrValue: Updater<T>, ref: Ref<T>) {
+  type UpdaterFn = (old: T) => T;
+  ref.value =
+    typeof updaterOrValue === "function"
+      ? (updaterOrValue as UpdaterFn)(ref.value)
+      : updaterOrValue;
 }

--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,7 @@
       "dependsOn": ["^lint"]
     },
     "check-types": {
-      "dependsOn": ["^check-types"]
+      "dependsOn": ["^build", "^check-types"]
     },
     "test": {
       "dependsOn": ["^build"]
@@ -20,7 +20,7 @@
     },
     "test:update": {},
     "test:watch": {
-      "cache": false, 
+      "cache": false,
       "persistent": true
     }
   }


### PR DESCRIPTION
Since this project is apparently discontinued, I have prepared a release (chrome extension only):  
https://github.com/alexchexes/demystify/releases

---

Closes #5

The issue this fixes:

While capturing traffic in the Chrome extension, automatic path parameterisation could fold unrelated resource paths into templates like `/api/{api}/...` or
multi-parameter paths such as `/api/{api}/{v2}/{param4}`. That made the generated OpenAPI shape hard to use: stable resource names like `/clients` or `/orders` could disappear into path params.

The heuristics also could not be disabled or narrowed, so a bad fold was hard to recover from.

This PR:

- Makes automatic folding more conservative:
  - ID-like path values (like `/api/order/123`, `/api/order/234`) can fold quickly, but only with compatible request and response shape evidence.
  - Query strings are stripped before matching path segments, so observed URLs such as `/orders/1?include=...` and `/orders/2?include=...` can still fold.
  - Text path values (like `/api/foo`, `/api/bar`) need **`4`** compatible observations.
  - Generic empty collection wrappers no longer trigger text folding by themselves.
- Adds schema-shape compatibility for normal API variation:
  - scalar type changes are allowed;
  - `null`, empty objects, and empty arrays are treated as unobserved inside that branch;
  - real object/array/scalar conflicts block folding.
- Stops folds from swallowing unrelated sibling routes and keeps existing parent endpoint data when child routes are folded.
- Adds global parameterisation controls:
  - shared UI checkboxes (auto-folding, IDs, text routes, compatible shape matching).
  - CLI mode via `--parameterisation safe-text|id-only|off`;
  - library options on `Representor`;

It also fixes repo tooling so lint/typecheck/test/build can run normally on Windows.

**Notes on design**

The shape matcher is intentionally heuristic as before, but the risky parts are split into small checks so they are easy to adjust later. Sparse branches are neutral rather than positive evidence: an empty array or object does not prove item shape, but it also does not count all populated item fields as missing. Folding still requires at least some compatible observed fields.

**Screenshots**

Before:

<img width="500" alt="chrome_2026-05-01--17-01-36--884" src="https://github.com/user-attachments/assets/ea0b7f06-da28-44c8-afb0-d6d13ce01108" />

**After:**

<img width="500" alt="image" src="https://github.com/user-attachments/assets/d8f1f1dd-67d1-4984-8fe3-2f32e50f6f11" />

**Remaining limitation**

The UI can rebuild parameterisation only from HAR entries captured or imported in the current session. Saved Demystify files don't contain raw HARs, so options changed via checkboxes apply only to future collected entries, not to the imported ones.
