### PR TITLE
Fix: Generate observed auth as OpenAPI security schemes

### DIFF
--- a/packages/algorithm/README.md
+++ b/packages/algorithm/README.md
@@ -5,6 +5,7 @@ Consists of a `Representor` class that accepts HAR entries and triages it. REST-
 See the interface in `Representor.ts` and `Rest.ts` for usage information, along with test files.
 
 Features:
+
 - Real time efficient generation of documents in any format from aggregated data, of which OpenAPI 3.1 is implemented
 - Automatic identification and parameterisation of path parameters
 - Merges new information into existing data
@@ -13,8 +14,18 @@ Features:
 - Handles mime types json, x-www-form-urlencoded, and xml
 - Minimal library use
 
+## Security generation
+
+Auth-looking request headers and cookies are emitted as OpenAPI security schemes
+and operation security requirements. They are not emitted as ordinary operation
+parameters, because they describe credentials rather than endpoint inputs.
+When multiple credentials are observed on the same request, each is emitted as a
+separate alternative because HAR data cannot prove which credential is actually
+required by the server. Observed `Authorization` headers are emitted both as
+Bearer auth and as a generic API-key header option.
+
 ```typescript
-import { Representor } from 'demystify-lib';
+import { Representor } from "demystify-lib";
 // Instantiate the representor
 // Which "represents" an API in a particular way, such as OpenAPI or GraphQL
 const representor = new Representor();

--- a/packages/algorithm/src/generate/generate-oai31.helpers.ts
+++ b/packages/algorithm/src/generate/generate-oai31.helpers.ts
@@ -7,6 +7,8 @@ import {
   RequestBodyObject,
   ResponseObject,
   ResponsesObject,
+  SecurityRequirementObject,
+  SecuritySchemeObject,
 } from "openapi3-ts/oas31";
 import { Endpoint } from "./yield-endpoints.js";
 import { NodeData } from "../types/index.js";
@@ -93,17 +95,100 @@ export const createQueryParameterObjects = (
   });
 };
 
-export const createCookieParameterObjects = (
-  cookies: NodeData["methods"]["get"]["cookies"],
-): Array<ParameterObject> => {
-  return cookies && Object.entries(cookies).map(([name/*, example*/]) => ({
+type ApiKeySecurityLocation = "cookie" | "header";
+
+type ApiKeySecurityDefinition = {
+  key: string;
+  scheme: SecuritySchemeObject;
+};
+
+type AuthSecurityDefinition = ApiKeySecurityDefinition & {
+  key: string;
+  scheme: SecuritySchemeObject;
+};
+
+const sanitiseSecurityKeyPart = (value: string): string => {
+  const sanitised = value.toLowerCase().replace(/[^a-z0-9._-]+/g, "_");
+  return sanitised || "credential";
+};
+
+const FNV1A_32_OFFSET_BASIS = 0x811c9dc5;
+const FNV1A_32_PRIME = 0x01000193;
+
+const createShortHash = (value: string): string => {
+  // FNV-1a is used here only as a small deterministic hash for component keys.
+  let hash = FNV1A_32_OFFSET_BASIS;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, FNV1A_32_PRIME);
+  }
+  return (hash >>> 0).toString(36).padStart(7, "0");
+};
+
+const getSecurityKeyName = (
+  location: ApiKeySecurityLocation,
+  name: string,
+): string => {
+  const canonicalName = location === "header" ? name.toLowerCase() : name;
+  return `apikey_${location}_${sanitiseSecurityKeyPart(name)}_${createShortHash(
+    `${location}:${canonicalName}`,
+  )}`;
+};
+
+const createApiKeySecurityDefinition = (
+  location: ApiKeySecurityLocation,
+  name: string,
+): ApiKeySecurityDefinition => ({
+  key: getSecurityKeyName(location, name),
+  scheme: {
+    type: "apiKey",
+    in: location,
     name,
-    required: true,
-    in: "cookie",
-    schema: {
-      type: "string",
+  },
+});
+
+const isAuthorizationHeader = (name: string): boolean =>
+  name.toLowerCase() === "authorization";
+
+const createHeaderSecurityDefinitions = (
+  name: string,
+): AuthSecurityDefinition[] => {
+  const apiKey = createApiKeySecurityDefinition("header", name);
+  if (!isAuthorizationHeader(name)) return [apiKey];
+  return [
+    {
+      key: "bearer",
+      scheme: {
+        type: "http",
+        scheme: "bearer",
+      },
     },
-  })) || [];
+    apiKey,
+  ];
+};
+
+export const createAuthSecurityDefinitions = (
+  headers: string[] = [],
+  cookies: NodeData["methods"]["get"]["cookies"],
+): AuthSecurityDefinition[] => [
+  ...headers.flatMap(createHeaderSecurityDefinitions),
+  ...Object.keys(cookies || {}).map((name) =>
+    createApiKeySecurityDefinition("cookie", name),
+  ),
+];
+
+export const createSecurityRequirementObjects = (
+  definitions: AuthSecurityDefinition[],
+): SecurityRequirementObject[] | undefined => {
+  if (!definitions.length) return undefined;
+  // HAR only proves which credentials were present, not which one is required.
+  // Keep each scheme as an alternative so generated clients can try them.
+  return definitions.map(
+    ({ key }) =>
+      ({
+        [key]: [],
+      }) as SecurityRequirementObject,
+  );
 };
 
 /**
@@ -124,7 +209,7 @@ export const createPathParameterObjects = (
     const actualName = actualPathname[i]!;
     if (isPartDynamic(paramName)) {
       parameters.push({
-        name: paramName.replace(/[{}]/g, ''),
+        name: paramName.replace(/[{}]/g, ""),
         in: "path",
         schema: {
           type: "string",

--- a/packages/algorithm/src/generate/generate-oai31.test.ts
+++ b/packages/algorithm/src/generate/generate-oai31.test.ts
@@ -1,19 +1,38 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
 import { Validator } from "@seriousme/openapi-schema-validator";
-import { generateOai31 } from './generate-oai31.js';
-import { OpenApiBuilder } from 'openapi3-ts/oas31';
-import { HostToNode } from '../types/index.js';
-import { Representor } from '../representor.js';
-import { createContent, createHarEntry } from '../__helpers__/index.js';
+import { generateOai31 } from "./generate-oai31.js";
+import { OpenApiBuilder } from "openapi3-ts/oas31";
+import { HostToNode } from "../types/index.js";
+import { Representor } from "../representor.js";
+import { createContent, createHarEntry } from "../__helpers__/index.js";
 
 const validateSpec = (builder: OpenApiBuilder) =>
   new Validator().validate(builder.getSpec());
 
-describe('generateOai31', () => {
+const getApiKeySecurityKey = (
+  builder: OpenApiBuilder,
+  name: string,
+  location: "cookie" | "header",
+) => {
+  const securitySchemes = builder.rootDoc.components?.securitySchemes || {};
+  return Object.keys(securitySchemes).find((key) => {
+    const scheme = securitySchemes[key]!;
+    return (
+      "type" in scheme &&
+      scheme.type === "apiKey" &&
+      "name" in scheme &&
+      scheme.name === name &&
+      "in" in scheme &&
+      scheme.in === location
+    );
+  });
+};
+
+describe("generateOai31", () => {
   const host = "api.example.com";
   const href = `https://${host}`;
 
-  it('should create an OpenAPI builder with correct metadata', async () => {
+  it("should create an OpenAPI builder with correct metadata", async () => {
     const representor = new Representor();
     const response1 = createContent({ test: 1 });
     const response2 = createContent({ test: false });
@@ -22,25 +41,30 @@ describe('generateOai31', () => {
         url: `${href}/a/b`,
         response: response1,
         queryString: [{ name: "query", value: "1" }],
-        cookies: [{ name: "token", value: "2" }]
-      })
+        cookies: [{ name: "token", value: "2" }],
+      }),
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/c`, response: response1 })
+      createHarEntry({ url: `${href}/a/c`, response: response1 }),
     );
     representor.upsert(
-      createHarEntry({ url: `${href}/a/TeSt`, response: response2, queryString: [{ name: "b", value: "2" }] })
+      createHarEntry({
+        url: `${href}/a/TeSt`,
+        response: response2,
+        queryString: [{ name: "b", value: "2" }],
+      }),
     );
     const hostToNode: HostToNode = {
-      [host]: representor.rest.data[host]!
+      [host]: representor.rest.data[host]!,
     };
     const result = generateOai31(hostToNode);
+    const tokenSecurityKey = getApiKeySecurityKey(result, "token", "cookie");
 
     expect(await validateSpec(result)).toEqual({ valid: true });
     expect(result).toBeInstanceOf(OpenApiBuilder);
-    expect(result.rootDoc.openapi).toBe('3.1.0');
-    expect(result.rootDoc.info.title).toBe('OpenAPI Specification');
-    expect(result.rootDoc.info.description).toContain('example.com');
+    expect(result.rootDoc.openapi).toBe("3.1.0");
+    expect(result.rootDoc.info.title).toBe("OpenAPI Specification");
+    expect(result.rootDoc.info.description).toContain("example.com");
     expect(result.rootDoc.servers).toHaveLength(1);
     expect(result.rootDoc.paths!["/a/{a}"]).toEqual({
       post: {
@@ -54,15 +78,10 @@ describe('generateOai31', () => {
                   type: "object",
                   properties: {
                     test: {
-                      type: [
-                        "boolean",
-                        "integer",
-                      ],
+                      type: ["boolean", "integer"],
                     },
                   },
-                  required: [
-                    "test",
-                  ],
+                  required: ["test"],
                 },
                 example: {
                   test: false,
@@ -70,8 +89,7 @@ describe('generateOai31', () => {
               },
             },
             description: "",
-            headers: {
-            },
+            headers: {},
           },
         },
         parameters: [
@@ -102,14 +120,11 @@ describe('generateOai31', () => {
               type: "string",
             },
           },
+        ],
+        security: [
           {
-            name: "token",
-            in: "cookie",
-            required: true,
-            schema: {
-              type: "string",
-            },
-          }
+            [tokenSecurityKey!]: [],
+          },
         ],
         requestBody: {
           content: {
@@ -121,9 +136,7 @@ describe('generateOai31', () => {
                     type: "string",
                   },
                 },
-                required: [
-                  "test",
-                ],
+                required: ["test"],
               },
               example: {
                 test: "integer",
@@ -132,6 +145,120 @@ describe('generateOai31', () => {
           },
         },
       },
-    })
+    });
+    expect(result.rootDoc.components?.securitySchemes).toEqual({
+      [tokenSecurityKey!]: {
+        type: "apiKey",
+        in: "cookie",
+        name: "token",
+      },
+    });
+  });
+
+  it("represents auth headers as operation security", async () => {
+    const representor = new Representor();
+    const entry = createHarEntry({
+      response: createContent({ ok: true }),
+      url: `${href}/csrf`,
+    });
+    entry.request.headers.push({ name: "X-CSRFToken", value: "abc" });
+    representor.upsert(entry);
+
+    const result = representor.rest.generate();
+    const csrfSecurityKey = getApiKeySecurityKey(
+      result,
+      "X-CSRFToken",
+      "header",
+    );
+
+    expect(result.rootDoc.components?.securitySchemes).toEqual({
+      [csrfSecurityKey!]: {
+        type: "apiKey",
+        in: "header",
+        name: "X-CSRFToken",
+      },
+    });
+    expect(result.rootDoc.paths?.["/csrf"]?.post?.security).toEqual([
+      {
+        [csrfSecurityKey!]: [],
+      },
+    ]);
+    expect(result.rootDoc.paths?.["/csrf"]?.post?.parameters).toBeUndefined();
+    expect(await validateSpec(result)).toEqual({ valid: true });
+  });
+
+  it("represents authorization headers as bearer and header alternatives", async () => {
+    const representor = new Representor();
+    const entry = createHarEntry({
+      response: createContent({ ok: true }),
+      url: `${href}/bearer`,
+    });
+    entry.request.headers.push({
+      name: "Authorization",
+      value: "Bearer token",
+    });
+    representor.upsert(entry);
+
+    const result = representor.rest.generate();
+    const authorizationSecurityKey = getApiKeySecurityKey(
+      result,
+      "Authorization",
+      "header",
+    );
+
+    expect(result.rootDoc.components?.securitySchemes).toEqual({
+      bearer: {
+        type: "http",
+        scheme: "bearer",
+      },
+      [authorizationSecurityKey!]: {
+        type: "apiKey",
+        in: "header",
+        name: "Authorization",
+      },
+    });
+    expect(result.rootDoc.paths?.["/bearer"]?.post?.security).toEqual([
+      {
+        bearer: [],
+      },
+      {
+        [authorizationSecurityKey!]: [],
+      },
+    ]);
+    expect(await validateSpec(result)).toEqual({ valid: true });
+  });
+
+  it("uses distinct security keys when sanitised credential names collide", async () => {
+    const representor = new Representor();
+    const entry = createHarEntry({
+      cookies: [
+        { name: "access+token", value: "one" },
+        { name: "access_token", value: "two" },
+      ],
+      response: createContent({ ok: true }),
+      url: `${href}/collision`,
+    });
+    entry.request.headers.push(
+      { name: "X-Api+Key", value: "one" },
+      { name: "X-Api_Key", value: "two" },
+    );
+    representor.upsert(entry);
+
+    const result = representor.rest.generate();
+    const keys = [
+      getApiKeySecurityKey(result, "X-Api+Key", "header"),
+      getApiKeySecurityKey(result, "X-Api_Key", "header"),
+      getApiKeySecurityKey(result, "access+token", "cookie"),
+      getApiKeySecurityKey(result, "access_token", "cookie"),
+    ];
+
+    expect(keys.every(Boolean)).toBe(true);
+    expect(new Set(keys).size).toBe(4);
+    expect(
+      result.rootDoc.paths?.["/collision"]?.post?.security?.map(
+        (requirement) => Object.keys(requirement)[0],
+      ),
+    ).toEqual(keys);
+    expect(await validateSpec(result)).toEqual({ valid: true });
   });
 });

--- a/packages/algorithm/src/generate/generate-oai31.ts
+++ b/packages/algorithm/src/generate/generate-oai31.ts
@@ -6,11 +6,12 @@ import {
 import { HostToNode } from "../types/index.js";
 import { yieldEndpoints } from "./yield-endpoints.js";
 import {
-  createCookieParameterObjects,
+  createAuthSecurityDefinitions,
   createPathParameterObjects,
   createQueryParameterObjects,
   createRequestBodyObject,
   createResponsesObject,
+  createSecurityRequirementObjects,
   shouldIncludeRequestBody,
 } from "./generate-oai31.helpers.js";
 
@@ -25,7 +26,6 @@ export function generateOai31(hostToNode: HostToNode): OpenApiBuilder {
     },
     paths: {},
   });
-  const headerCombos: { [s: string]: string[] } = {};
   for (const [host, rootNode] of Object.entries(hostToNode)) {
     builder.addServer({
       url: `http://${host}`,
@@ -41,18 +41,22 @@ export function generateOai31(hostToNode: HostToNode): OpenApiBuilder {
         node: { data },
         pathname,
       } = endpoint;
-      const pathParameterObjects = createPathParameterObjects(pathname, data.mostRecentPathname.split('/'));
+      const pathParameterObjects = createPathParameterObjects(
+        pathname,
+        data.mostRecentPathname.split("/"),
+      );
       const fullPathname = `/${pathname.slice(1).join("/")}`;
       for (const method of Object.keys(data.methods)) {
-        const requestHeaders = data.methods[method]?.requestHeaders || [] as string[];
-        const reqAuthName = requestHeaders.join("");
-        if (reqAuthName) {
-          headerCombos[reqAuthName] = requestHeaders;
-        }
-
         const endpointMethod = data.methods[method]!;
+        const authSecurityDefinitions = createAuthSecurityDefinitions(
+          endpointMethod.requestHeaders,
+          endpointMethod.cookies,
+        );
+        for (const { key, scheme } of authSecurityDefinitions) {
+          builder.addSecurityScheme(key, scheme);
+        }
         const queryParameterObjects = createQueryParameterObjects(
-          endpointMethod.queryParameters
+          endpointMethod.queryParameters,
         );
         const requestBody = createRequestBodyObject(endpointMethod.request);
         const responses = createResponsesObject(
@@ -64,14 +68,18 @@ export function generateOai31(hostToNode: HostToNode): OpenApiBuilder {
           description: `**host**: ${data.protocol}//${host}`,
           responses,
         };
-        const cookieParameterObjects = createCookieParameterObjects(endpointMethod.cookies);
         const allParameterObjects = [
           ...pathParameterObjects,
           ...queryParameterObjects,
-          ...cookieParameterObjects,
         ];
         if (allParameterObjects.length) {
           operation.parameters = allParameterObjects;
+        }
+        const security = createSecurityRequirementObjects(
+          authSecurityDefinitions,
+        );
+        if (security) {
+          operation.security = security;
         }
         if (requestBody && shouldIncludeRequestBody(method)) {
           operation.requestBody = requestBody;
@@ -88,18 +96,6 @@ export function generateOai31(hostToNode: HostToNode): OpenApiBuilder {
         }
       }
     }
-  }
-  for (const headerNames of Object.values(headerCombos)) {
-    let count = 1;
-    const authNameFinal = `Header Auth ${count}`;
-    for (const headerName of headerNames) {
-      builder.addSecurityScheme(authNameFinal, {
-        type: "apiKey",
-        in: "header",
-        name: headerName,
-      });
-    }
-    count++;
   }
   return builder;
 }

--- a/packages/algorithm/src/update-or-create/__snapshots__/update-or-create.test.ts.snap
+++ b/packages/algorithm/src/update-or-create/__snapshots__/update-or-create.test.ts.snap
@@ -58,7 +58,9 @@ exports[`findOrCreate REST JSON > when rootNode is not provided, return a new ro
                     },
                   },
                 },
-                "requestHeaders": [],
+                "requestHeaders": [
+                  "Authorization",
+                ],
                 "response": {
                   "201": {
                     "application/json": {
@@ -195,7 +197,9 @@ exports[`findOrCreate REST JSON alternative > merges harEntry into an existing n
                     },
                   },
                 },
-                "requestHeaders": [],
+                "requestHeaders": [
+                  "Authorization",
+                ],
                 "response": {
                   "201": {
                     "application/json": {
@@ -532,7 +536,9 @@ exports[`findOrCreate XML > merges data into an existing node 1`] = `
                     "mostRecent": "<?xml version="1.0" encoding="UTF-8"?><pet><name>Fluffy</name><type>cat</type><age>3</age><vaccinated>true</vaccinated><tags><tag>friendly</tag><tag>indoor</tag></tags></pet>",
                   },
                 },
-                "requestHeaders": [],
+                "requestHeaders": [
+                  "Authorization",
+                ],
                 "response": {
                   "201": {
                     "application/xml": {
@@ -799,7 +805,9 @@ exports[`findOrCreate XML > when rootNode is not provided, return a new root nod
                     "mostRecent": "<?xml version="1.0" encoding="UTF-8"?><pet><name>Fluffy</name><type>cat</type><age>3</age><vaccinated>true</vaccinated><tags><tag>friendly</tag><tag>indoor</tag></tags></pet>",
                   },
                 },
-                "requestHeaders": [],
+                "requestHeaders": [
+                  "Authorization",
+                ],
                 "response": {
                   "201": {
                     "application/xml": {

--- a/packages/algorithm/src/utils/headers.test.ts
+++ b/packages/algorithm/src/utils/headers.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { getAuthHeaders } from "./headers.js";
+
+describe("getAuthHeaders", () => {
+  it("keeps ignored protocol headers out of auth detection", () => {
+    const result = getAuthHeaders([
+      { name: "Sec-WebSocket-Key", value: "abc" },
+      { name: "Authorization", value: "Bearer token" },
+      { name: "X-CSRF-Token", value: "csrf" },
+      { name: "X-CSRFToken", value: "csrf" },
+    ]);
+
+    expect(result).toEqual(["Authorization", "X-CSRF-Token", "X-CSRFToken"]);
+  });
+});

--- a/packages/algorithm/src/utils/headers.ts
+++ b/packages/algorithm/src/utils/headers.ts
@@ -241,10 +241,21 @@ const isAuthHeader = (header: string) => {
   return mustContain.some((v) => stripSpecialChars.includes(v));
 };
 
+const isIgnoredAuthHeader = (header: string) => {
+  const toLower = header.toLowerCase();
+  const stripSpecialChars = toLower.replace(/[^a-z0-9]/g, "");
+  return toLower === "authorization" || stripSpecialChars.includes("csrf");
+};
+
 export const getAuthHeaders = (headers: Entry["request"]["headers"]) => {
-  const withoutDefaultHeaders = filterIgnoreHeaders(headers);
   const out: string[] = [];
-  for (const header of withoutDefaultHeaders) {
+  for (const header of headers) {
+    if (
+      headersToIgnore.has(header.name.toLowerCase()) &&
+      !isIgnoredAuthHeader(header.name)
+    ) {
+      continue;
+    }
     if (isAuthHeader(header.name)) out.push(header.name);
   }
   return out;


### PR DESCRIPTION
This changes auth-looking request headers and cookies to be represented as OpenAPI security schemes, instead of regular operation parameters.

`Authorization` is handled again too: when it is observed, the generated spec includes both Bearer auth and a generic API-key header option. If a request has several credentials, they are listed as separate alternatives, since the HAR only tells us what was sent, not which one the server actually requires.

This also avoids a couple of bad cases:
- protocol headers like `Sec-WebSocket-Key` are ignored instead of becoming auth schemes;
- similar names like `X-Api+Key` and `X-Api_Key` no longer overwrite each other after sanitising.

---

Since this project is apparently discontinued, I have prepared a release (chrome extension only):  
https://github.com/alexchexes/demystify/releases 
