### PR TITLE
Fix: Use observed protocol for generated OpenAPI servers

### DIFF
--- a/packages/algorithm/src/generate/generate-oai31.test.ts
+++ b/packages/algorithm/src/generate/generate-oai31.test.ts
@@ -42,6 +42,7 @@ describe('generateOai31', () => {
     expect(result.rootDoc.info.title).toBe('OpenAPI Specification');
     expect(result.rootDoc.info.description).toContain('example.com');
     expect(result.rootDoc.servers).toHaveLength(1);
+    expect(result.rootDoc.servers?.[0]?.url).toBe("https://api.example.com");
     expect(result.rootDoc.paths!["/a/{a}"]).toEqual({
       post: {
         summary: "/a/{a}",

--- a/packages/algorithm/src/generate/generate-oai31.ts
+++ b/packages/algorithm/src/generate/generate-oai31.ts
@@ -27,16 +27,20 @@ export function generateOai31(hostToNode: HostToNode): OpenApiBuilder {
   });
   const headerCombos: { [s: string]: string[] } = {};
   for (const [host, rootNode] of Object.entries(hostToNode)) {
-    builder.addServer({
-      url: `http://${host}`,
-      variables: {
-        host: {
-          default: "localhost",
-          description: "The host of the server",
+    const endpoints = Array.from(yieldEndpoints([rootNode]));
+    const protocols = new Set(endpoints.map(({ node }) => node.data.protocol));
+    for (const protocol of protocols) {
+      builder.addServer({
+        url: `${protocol}//${host}`,
+        variables: {
+          host: {
+            default: "localhost",
+            description: "The host of the server",
+          },
         },
-      },
-    });
-    for (const endpoint of yieldEndpoints([rootNode])) {
+      });
+    }
+    for (const endpoint of endpoints) {
       const {
         node: { data },
         pathname,


### PR DESCRIPTION
This fixes generated OpenAPI `servers` so they use the protocol observed in the HAR.

Before this, an operation description could show `https://...`, while the root `servers` entry still said `http://...`.

---

Since this project is apparently discontinued, I have prepared a release (chrome extension only):  
https://github.com/alexchexes/demystify/releases
